### PR TITLE
Expand documentation and cosmetics changes to timestamping and zero-copy

### DIFF
--- a/groups/nts/ntsa/ntsa_notification.cpp
+++ b/groups/nts/ntsa/ntsa_notification.cpp
@@ -31,8 +31,8 @@ Notification::Notification(const Notification& original)
         new (d_timestamp.buffer())
             ntsa::Timestamp(original.d_timestamp.object());
         break;
-    case (ntsa::NotificationType::e_MSG_ZEROCOPY):
-        new (d_zerocopy.buffer()) ntsa::ZeroCopy(original.d_zerocopy.object());
+    case (ntsa::NotificationType::e_ZERO_COPY):
+        new (d_zeroCopy.buffer()) ntsa::ZeroCopy(original.d_zeroCopy.object());
         break;
     default:
         BSLS_ASSERT(d_type == ntsa::NotificationType::e_UNDEFINED);
@@ -53,8 +53,8 @@ Notification& Notification::operator=(const Notification& other)
     case (ntsa::NotificationType::e_TIMESTAMP):
         new (d_timestamp.buffer()) ntsa::Timestamp(other.d_timestamp.object());
         break;
-    case (ntsa::NotificationType::e_MSG_ZEROCOPY):
-        new (d_zerocopy.buffer()) ntsa::ZeroCopy(other.d_zerocopy.object());
+    case (ntsa::NotificationType::e_ZERO_COPY):
+        new (d_zeroCopy.buffer()) ntsa::ZeroCopy(other.d_zeroCopy.object());
         break;
     default:
         BSLS_ASSERT(d_type == ntsa::NotificationType::e_UNDEFINED);
@@ -72,8 +72,8 @@ bool Notification::equals(const Notification& other) const
     switch (d_type) {
     case ntsa::NotificationType::e_TIMESTAMP:
         return d_timestamp.object() == other.d_timestamp.object();
-    case ntsa::NotificationType::e_MSG_ZEROCOPY:
-        return d_zerocopy.object() == other.d_zerocopy.object();
+    case ntsa::NotificationType::e_ZERO_COPY:
+        return d_zeroCopy.object() == other.d_zeroCopy.object();
     default:
         return true;
     }
@@ -88,8 +88,8 @@ bool Notification::less(const Notification& other) const
     switch (d_type) {
     case ntsa::NotificationType::e_TIMESTAMP:
         return d_timestamp.object() < other.d_timestamp.object();
-    case ntsa::NotificationType::e_MSG_ZEROCOPY:
-        return d_zerocopy.object() < other.d_zerocopy.object();
+    case ntsa::NotificationType::e_ZERO_COPY:
+        return d_zeroCopy.object() < other.d_zeroCopy.object();
     default:
         return true;
     }
@@ -103,8 +103,8 @@ bsl::ostream& Notification::print(bsl::ostream& stream,
     case ntsa::NotificationType::e_TIMESTAMP:
         d_timestamp.object().print(stream, level, spacesPerLevel);
         break;
-    case ntsa::NotificationType::e_MSG_ZEROCOPY:
-        d_zerocopy.object().print(stream, level, spacesPerLevel);
+    case ntsa::NotificationType::e_ZERO_COPY:
+        d_zeroCopy.object().print(stream, level, spacesPerLevel);
         break;
     default:
         BSLS_ASSERT(d_type == ntsa::NotificationType::e_UNDEFINED);

--- a/groups/nts/ntsa/ntsa_notification.h
+++ b/groups/nts/ntsa/ntsa_notification.h
@@ -32,8 +32,8 @@ namespace ntsa {
 /// Provide a union of notifications.
 ///
 /// @details
-/// Provide a value-semantic type that represents a discriminated
-/// union of notifications.
+/// Provide a value-semantic type that represents a discriminated union of
+/// notifications.
 //
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -43,7 +43,7 @@ class Notification
 {
     union {
         bsls::ObjectBuffer<ntsa::Timestamp> d_timestamp;
-        bsls::ObjectBuffer<ntsa::ZeroCopy>  d_zerocopy;
+        bsls::ObjectBuffer<ntsa::ZeroCopy>  d_zeroCopy;
     };
 
     ntsa::NotificationType::Value d_type;
@@ -52,19 +52,18 @@ class Notification
     /// Create a new notification having an undefined type.
     Notification();
 
-    /// Create a new notification the same value as the specified 'other'
-    /// object.
+    /// Create a new notification having the same value as the specified
+    /// 'other' object.
     Notification(const Notification& other);
 
     /// Destroy this object.
     ~Notification();
 
-    /// Assign the value of the specified 'other' object to this object.
-    /// Return a reference to this modifiable object.
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
     Notification& operator=(const Notification& other);
 
-    /// Reset the value of this object to its value upon default
-    /// construction.
+    /// Reset the value of this object to its value upon default construction.
     void reset();
 
     /// Select the "timestamp" representation. Return a reference to the
@@ -73,22 +72,22 @@ class Notification
 
     /// Select the "timestamp" representation initially having the specified
     /// 'value'. Return a reference to the modifiable representation.
-    ntsa::Timestamp& makeTimestamp(const ntsa::Timestamp& ts);
+    ntsa::Timestamp& makeTimestamp(const ntsa::Timestamp& value);
 
-    /// Select the "zerocopy" representation. Return a reference to the
+    /// Select the "zeroCopy" representation. Return a reference to the
     /// modifiable representation.
     ntsa::ZeroCopy& makeZeroCopy();
 
-    /// Select the "zerocopy" representation initially having the specified
+    /// Select the "zeroCopy" representation initially having the specified
     /// 'value'. Return a reference to the modifiable representation.
-    ntsa::ZeroCopy& makeZeroCopy(const ntsa::ZeroCopy& zc);
+    ntsa::ZeroCopy& makeZeroCopy(const ntsa::ZeroCopy& value);
 
-    /// Return a reference to the "timestamp" representation.
-    /// The behavior is undefined unless 'isTimestamp()' is true.
+    /// Return a reference to the "timestamp" representation. The behavior is
+    /// undefined unless 'isTimestamp()' is true.
     const ntsa::Timestamp& timestamp() const;
 
-    /// Return a reference to the "zerocopy" representation.
-    /// The behavior is undefined unless 'isZeroCopy()' is true.
+    /// Return a reference to the "zeroCopy" representation. The behavior is
+    /// undefined unless 'isZeroCopy()' is true.
     const ntsa::ZeroCopy& zeroCopy() const;
 
     /// Return the type of the notification representation.
@@ -98,7 +97,7 @@ class Notification
     /// otherwise return false.
     bool isTimestamp() const;
 
-    /// Return true if the "zerocopy" representation is currently selected,
+    /// Return true if the "zeroCopy" representation is currently selected,
     /// otherwise return false.
     bool isZeroCopy() const;
 
@@ -106,37 +105,36 @@ class Notification
     /// return false.
     bool isUndefined() const;
 
-    /// Return true if this object has the same value as the specified
-    /// 'other' object, otherwise return false.
+    /// Return true if this object has the same value as the specified 'other'
+    /// object, otherwise return false.
     bool equals(const Notification& other) const;
 
-    /// Return true if the value of this object is less than the value of
-    /// the specified 'other' object, otherwise return false.
+    /// Return true if the value of this object is less than the value of the
+    /// specified 'other' object, otherwise return false.
     bool less(const Notification& other) const;
 
-    /// Format this object to the specified output 'stream' at the
-    /// optionally specified indentation 'level' and return a reference to
-    /// the modifiable 'stream'.  If 'level' is specified, optionally
-    /// specify 'spacesPerLevel', the number of spaces per indentation level
-    /// for this and all of its nested objects.  Each line is indented by
-    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    /// negative, suppress indentation of the first line.  If
-    /// 'spacesPerLevel' is negative, suppress line breaks and format the
-    /// entire output on one line.  If 'stream' is initially invalid, this
-    /// operation has no effect.  Note that a trailing newline is provided
-    /// in multiline mode only.
+    /// Format this object to the specified output 'stream' at the optionally
+    /// specified indentation 'level' and return a reference to the modifiable
+    /// 'stream'.  If 'level' is specified, optionally specify
+    /// 'spacesPerLevel', the number of spaces per indentation level for this
+    /// and all of its nested objects.  Each line is indented by the absolute
+    /// value of 'level * spacesPerLevel'.  If 'level' is negative, suppress
+    /// indentation of the first line.  If 'spacesPerLevel' is negative,
+    /// suppress line breaks and format the entire output on one line.  If
+    /// 'stream' is initially invalid, this operation has no effect.  Note that
+    /// a trailing newline is provided in multiline mode only.
     bsl::ostream& print(bsl::ostream& stream,
                         int           level          = 0,
                         int           spacesPerLevel = 4) const;
 
-    /// Defines the traits of this type. These traits can be used to select,
-    /// at compile-time, the most efficient algorithm to manipulate objects
-    /// of this type.
+    /// Defines the traits of this type. These traits can be used to select, at
+    /// compile-time, the most efficient algorithm to manipulate objects of
+    /// this type.
     NTSCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(Notification);
 };
 
-/// Write the specified 'object' to the specified 'stream'. Return a
-/// modifiable reference to the 'stream'.
+/// Write the specified 'object' to the specified 'stream'. Return a modifiable
+/// reference to the 'stream'.
 ///
 /// @related ntsa::Notification
 bsl::ostream& operator<<(bsl::ostream& stream, const Notification& object);
@@ -159,8 +157,8 @@ bool operator!=(const Notification& lhs, const Notification& rhs);
 /// @related ntsa::Notification
 bool operator<(const Notification& lhs, const Notification& rhs);
 
-/// Contribute the values of the salient attributes of the specified 'value'
-/// to the specified hash 'algorithm'.
+/// Contribute the values of the salient attributes of the specified 'value' to
+/// the specified hash 'algorithm'.
 ///
 /// @related ntsa::Notification
 template <typename HASH_ALGORITHM>
@@ -199,14 +197,14 @@ ntsa::Timestamp& Notification::makeTimestamp()
 }
 
 NTSCFG_INLINE
-ntsa::Timestamp& Notification::makeTimestamp(const ntsa::Timestamp& ts)
+ntsa::Timestamp& Notification::makeTimestamp(const ntsa::Timestamp& value)
 {
     if (d_type == ntsa::NotificationType::e_TIMESTAMP) {
-        d_timestamp.object() = ts;
+        d_timestamp.object() = value;
     }
     else {
         this->reset();
-        new (d_timestamp.buffer()) ntsa::Timestamp(ts);
+        new (d_timestamp.buffer()) ntsa::Timestamp(value);
         d_type = ntsa::NotificationType::e_TIMESTAMP;
     }
 
@@ -216,31 +214,31 @@ ntsa::Timestamp& Notification::makeTimestamp(const ntsa::Timestamp& ts)
 NTSCFG_INLINE
 ntsa::ZeroCopy& Notification::makeZeroCopy()
 {
-    if (d_type == ntsa::NotificationType::e_MSG_ZEROCOPY) {
-        d_zerocopy.object() = ntsa::ZeroCopy();
+    if (d_type == ntsa::NotificationType::e_ZERO_COPY) {
+        d_zeroCopy.object() = ntsa::ZeroCopy();
     }
     else {
         this->reset();
-        new (d_zerocopy.buffer()) ntsa::ZeroCopy();
-        d_type = ntsa::NotificationType::e_MSG_ZEROCOPY;
+        new (d_zeroCopy.buffer()) ntsa::ZeroCopy();
+        d_type = ntsa::NotificationType::e_ZERO_COPY;
     }
 
-    return d_zerocopy.object();
+    return d_zeroCopy.object();
 }
 
 NTSCFG_INLINE
-ntsa::ZeroCopy& Notification::makeZeroCopy(const ntsa::ZeroCopy& zc)
+ntsa::ZeroCopy& Notification::makeZeroCopy(const ntsa::ZeroCopy& value)
 {
-    if (d_type == ntsa::NotificationType::e_MSG_ZEROCOPY) {
-        d_zerocopy.object() = zc;
+    if (d_type == ntsa::NotificationType::e_ZERO_COPY) {
+        d_zeroCopy.object() = value;
     }
     else {
         this->reset();
-        new (d_zerocopy.buffer()) ntsa::ZeroCopy(zc);
-        d_type = ntsa::NotificationType::e_MSG_ZEROCOPY;
+        new (d_zeroCopy.buffer()) ntsa::ZeroCopy(value);
+        d_type = ntsa::NotificationType::e_ZERO_COPY;
     }
 
-    return d_zerocopy.object();
+    return d_zeroCopy.object();
 }
 
 NTSCFG_INLINE
@@ -253,8 +251,8 @@ const ntsa::Timestamp& Notification::timestamp() const
 NTSCFG_INLINE
 const ntsa::ZeroCopy& Notification::zeroCopy() const
 {
-    BSLS_ASSERT(d_type == ntsa::NotificationType::e_MSG_ZEROCOPY);
-    return d_zerocopy.object();
+    BSLS_ASSERT(d_type == ntsa::NotificationType::e_ZERO_COPY);
+    return d_zeroCopy.object();
 }
 
 NTSCFG_INLINE
@@ -272,7 +270,7 @@ bool Notification::isTimestamp() const
 NTSCFG_INLINE
 bool Notification::isZeroCopy() const
 {
-    return d_type == ntsa::NotificationType::e_MSG_ZEROCOPY;
+    return d_type == ntsa::NotificationType::e_ZERO_COPY;
 }
 
 NTSCFG_INLINE

--- a/groups/nts/ntsa/ntsa_notification.t.cpp
+++ b/groups/nts/ntsa/ntsa_notification.t.cpp
@@ -128,7 +128,7 @@ NTSCFG_TEST_CASE(6)
     NTSCFG_TEST_TRUE(n.isZeroCopy());
     NTSCFG_TEST_FALSE(n.isUndefined());
     NTSCFG_TEST_FALSE(n.isTimestamp());
-    NTSCFG_TEST_EQ(n.type(), NotificationType::e_MSG_ZEROCOPY);
+    NTSCFG_TEST_EQ(n.type(), NotificationType::e_ZERO_COPY);
 
     zc.setFrom(1);
     zc.setTo(22);

--- a/groups/nts/ntsa/ntsa_notificationtype.cpp
+++ b/groups/nts/ntsa/ntsa_notificationtype.cpp
@@ -28,7 +28,7 @@ int NotificationType::fromInt(NotificationType::Value* result, int number)
     switch (number) {
     case NotificationType::e_UNDEFINED:
     case NotificationType::e_TIMESTAMP:
-    case NotificationType::e_MSG_ZEROCOPY:
+    case NotificationType::e_ZERO_COPY:
         *result = static_cast<NotificationType::Value>(number);
         return 0;
     default:
@@ -47,8 +47,8 @@ int NotificationType::fromString(NotificationType::Value* result,
         *result = e_TIMESTAMP;
         return 0;
     }
-    if (bdlb::String::areEqualCaseless(string, "MSG_ZEROCOPY")) {
-        *result = e_MSG_ZEROCOPY;
+    if (bdlb::String::areEqualCaseless(string, "ZERO_COPY")) {
+        *result = e_ZERO_COPY;
         return 0;
     }
 
@@ -64,8 +64,8 @@ const char* NotificationType::toString(NotificationType::Value value)
     case e_TIMESTAMP: {
         return "TIMESTAMP";
     } break;
-    case e_MSG_ZEROCOPY: {
-        return "MSG_ZEROCOPY";
+    case e_ZERO_COPY: {
+        return "ZERO_COPY";
     } break;
     }
 

--- a/groups/nts/ntsa/ntsa_notificationtype.h
+++ b/groups/nts/ntsa/ntsa_notificationtype.h
@@ -34,7 +34,17 @@ namespace ntsa {
 struct NotificationType {
   public:
     /// Provide an enumeration of the notification types.
-    enum Value { e_UNDEFINED = 0, e_TIMESTAMP = 1, e_MSG_ZEROCOPY = 2 };
+    enum Value { 
+        /// The notification type is not defined.
+        e_UNDEFINED = 0, 
+
+        /// The notification describes a timestamp for outgoing data.
+        e_TIMESTAMP = 1, 
+
+        /// The notification describes the completion of one or more zero-copy
+        /// operations to enqueue data to the socket send buffer.
+        e_ZERO_COPY = 2 
+    };
 
     /// Return the string representation exactly matching the enumerator
     /// name corresponding to the specified enumeration 'value'.

--- a/groups/nts/ntsa/ntsa_notificationtype.t.cpp
+++ b/groups/nts/ntsa/ntsa_notificationtype.t.cpp
@@ -31,8 +31,8 @@ NTSCFG_TEST_CASE(1)
                     "TIMESTAMP"),
         0);
     NTSCFG_TEST_EQ(bsl::strcmp(NotificationType::toString(
-                                   NotificationType::e_MSG_ZEROCOPY),
-                               "MSG_ZEROCOPY"),
+                                   NotificationType::e_ZERO_COPY),
+                               "ZERO_COPY"),
                    0);
 }
 
@@ -50,17 +50,17 @@ NTSCFG_TEST_CASE(2)
     NTSCFG_TEST_EQ(v, NotificationType::e_TIMESTAMP);
 
     NTSCFG_TEST_EQ(NotificationType::fromInt(&v, 2), 0);
-    NTSCFG_TEST_EQ(v, NotificationType::e_MSG_ZEROCOPY);
+    NTSCFG_TEST_EQ(v, NotificationType::e_ZERO_COPY);
 
     NTSCFG_TEST_EQ(NotificationType::fromInt(&v, 3), -1);
-    NTSCFG_TEST_EQ(v, NotificationType::e_MSG_ZEROCOPY);
+    NTSCFG_TEST_EQ(v, NotificationType::e_ZERO_COPY);
 }
 
 NTSCFG_TEST_CASE(3)
 {
     const bsl::string undefined = "undefined";
     const bsl::string timestamp = "timestamp";
-    const bsl::string zerocopy  = "msg_zerocopy";
+    const bsl::string zerocopy  = "zero_copy";
     const bsl::string random    = "random_string";
 
     NotificationType::Value v = NotificationType::e_TIMESTAMP;
@@ -75,7 +75,7 @@ NTSCFG_TEST_CASE(3)
     NTSCFG_TEST_EQ(v, NotificationType::e_TIMESTAMP);
 
     NTSCFG_TEST_EQ(NotificationType::fromString(&v, zerocopy), 0);
-    NTSCFG_TEST_EQ(v, NotificationType::e_MSG_ZEROCOPY);
+    NTSCFG_TEST_EQ(v, NotificationType::e_ZERO_COPY);
 }
 
 NTSCFG_TEST_CASE(4)
@@ -84,9 +84,9 @@ NTSCFG_TEST_CASE(4)
 
     ss << NotificationType::e_TIMESTAMP << ", "
        << NotificationType::e_UNDEFINED << ", "
-       << NotificationType::e_MSG_ZEROCOPY;
+       << NotificationType::e_ZERO_COPY;
 
-    NTSCFG_TEST_EQ(ss.str(), "TIMESTAMP, UNDEFINED, MSG_ZEROCOPY");
+    NTSCFG_TEST_EQ(ss.str(), "TIMESTAMP, UNDEFINED, ZERO_COPY");
 }
 
 NTSCFG_TEST_DRIVER

--- a/groups/nts/ntsa/ntsa_sendoptions.h
+++ b/groups/nts/ntsa/ntsa_sendoptions.h
@@ -79,14 +79,18 @@ namespace ntsa {
 /// zero, or, for stream sockets only, to NTSCFG_DEFAULT_MAX_INPLACE_BUFFERS.
 /// Note that this value is currently only honored when sending blobs.
 ///
-/// @li @b d_zeroCopy:
-/// The option is applicable only for Linux. If the flag is true then the OS is
-/// requested to use copy avoidance mechanism (Linux MSG_ZEROCOPY). If the flag
-/// is set to true then the user must ensure that transmitted data is not
-/// touched (e.g. deallocated) until the OS acknowledges it (via socket error
-/// queue notification mechanism). Note that the OS has the right to do copy
-/// data anyway. The actual status (if the data was copied or not) is learned
-/// from examining the error queue.
+/// @li @b zeroCopy:
+/// The flag to request the data-to-send be referenced in-place rather than
+/// copied to the send buffer to the specified 'value'. Note that this flag is
+/// advisory; the operating system may neither support nor decide to allow
+/// zero-copy semantics. Regardless, if zero-copy semantics are requested the
+/// application must ensure the data-to-send is neither overwritten nor
+/// invalidated (i.e. freed) until the completion of the send operation is
+/// indicated in a subsequent notification (which also indicates whether the
+/// data was referenced in-place or copied.) Also note that this option is only
+/// supported on platforms where 'ntscfg::Platform::supportsZeroCopy()' returns
+/// true. Send operations requesting zero-copy semantics on platforms that do
+/// not support zero-copy will result in an error.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -127,13 +131,13 @@ class SendOptions
     // 'value'.
     void setForeignHandle(ntsa::Handle value);
 
-    /// Set the maximum number of bytes to copy to the specified 'value'.
+    /// Set the maximum number of bytes to send to the specified 'value'.
     void setMaxBytes(bsl::size_t value);
 
-    /// Set the maximum number of buffers to copy to the specified 'value'.
+    /// Set the maximum number of buffers to send to the specified 'value'.
     void setMaxBuffers(bsl::size_t value);
 
-    /// Set the MSG_ZEROCOPY flag to the specified 'value'.
+    /// Set the flag to request zero-copy semantics to the specified 'value'.
     void setZeroCopy(bool value);
 
     /// Return the remote endpoint to which the data should be sent.
@@ -142,13 +146,13 @@ class SendOptions
     /// Return the handle to the open socket to send to the peer.
     const bdlb::NullableValue<ntsa::Handle>& foreignHandle() const;
 
-    /// Return the maximum number of bytes to copy.
+    /// Return the maximum number of bytes to send.
     bsl::size_t maxBytes() const;
 
-    /// Return the maximum number of buffers to copy.
+    /// Return the maximum number of buffers to send.
     bsl::size_t maxBuffers() const;
 
-    /// Return true is MSG_ZEROCOPY is set to true. Otherwise return false.
+    /// Return the flag that indicates zero-copy semantics are requested.
     bool zeroCopy() const;
 
     /// Return true if this object has the same value as the specified

--- a/groups/nts/ntsa/ntsa_socketconfig.cpp
+++ b/groups/nts/ntsa/ntsa_socketconfig.cpp
@@ -73,6 +73,9 @@ void SocketConfig::setOption(const ntsa::SocketOption& option)
     else if (option.isTimestampOutgoingData()) {
         d_timestampOutgoingData = option.timestampOutgoingData();
     }
+    else if (option.isZeroCopy()) {
+        d_zeroCopy = option.zeroCopy();
+    }
 }
 
 void SocketConfig::getOption(ntsa::SocketOption*           option,
@@ -162,6 +165,11 @@ void SocketConfig::getOption(ntsa::SocketOption*           option,
             option->makeTimestampOutgoingData(d_timestampOutgoingData.value());
         }
     }
+    else if (type == ntsa::SocketOptionType::e_ZERO_COPY) {
+        if (!d_zeroCopy.isNull()) {
+            option->makeZeroCopy(d_zeroCopy.value());
+        }
+    }
 }
 
 bool SocketConfig::equals(const SocketConfig& other) const
@@ -179,7 +187,8 @@ bool SocketConfig::equals(const SocketConfig& other) const
            d_bypassRouting == other.d_bypassRouting &&
            d_inlineOutOfBandData == other.d_inlineOutOfBandData &&
            d_timestampIncomingData == other.d_timestampIncomingData &&
-           d_timestampOutgoingData == other.d_timestampOutgoingData;
+           d_timestampOutgoingData == other.d_timestampOutgoingData &&
+           d_zeroCopy == other.d_zeroCopy;
 }
 
 bool SocketConfig::less(const SocketConfig& other) const
@@ -304,7 +313,15 @@ bool SocketConfig::less(const SocketConfig& other) const
         return false;
     }
 
-    return d_timestampOutgoingData < other.d_timestampOutgoingData;
+    if (d_timestampOutgoingData < other.d_timestampOutgoingData) {
+        return true;
+    }
+
+    if (other.d_timestampOutgoingData < d_timestampOutgoingData) {
+        return false;
+    }
+
+    return d_zeroCopy < other.d_zeroCopy;
 }
 
 bsl::ostream& SocketConfig::print(bsl::ostream& stream,
@@ -313,24 +330,83 @@ bsl::ostream& SocketConfig::print(bsl::ostream& stream,
 {
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
-    printer.printAttribute("reuseAddress", d_reuseAddress);
-    printer.printAttribute("d_keepAlive", d_keepAlive);
-    printer.printAttribute("d_cork", d_cork);
-    printer.printAttribute("d_delayTransmission", d_delayTransmission);
-    printer.printAttribute("d_delayAcknowledgement", d_delayAcknowledgement);
-    printer.printAttribute("d_sendBufferSize", d_sendBufferSize);
-    printer.printAttribute("d_sendBufferLowWatermark",
-                           d_sendBufferLowWatermark);
-    printer.printAttribute("d_receiveBufferSize", d_receiveBufferSize);
-    printer.printAttribute("d_receiveBufferLowWatermark",
-                           d_receiveBufferLowWatermark);
-    printer.printAttribute("d_debug", d_debug);
-    printer.printAttribute("d_linger", d_linger);
-    printer.printAttribute("d_broadcast", d_broadcast);
-    printer.printAttribute("d_bypassRouting", d_bypassRouting);
-    printer.printAttribute("d_inlineOutOfBandData", d_inlineOutOfBandData);
-    printer.printAttribute("d_timestampIncomingData", d_timestampIncomingData);
-    printer.printAttribute("d_timestampOutgoingData", d_timestampOutgoingData);
+
+    if (!d_reuseAddress.isNull()) {
+        printer.printAttribute("reuseAddress", d_reuseAddress.value());
+    }
+
+    if (!d_keepAlive.isNull()) {
+        printer.printAttribute("keepAlive", d_keepAlive.value());
+    }
+
+    if (!d_cork.isNull()) {
+        printer.printAttribute("cork", d_cork.value());
+    }
+
+    if (!d_delayTransmission.isNull()) {
+        printer.printAttribute("delayTransmission", 
+                               d_delayTransmission.value());
+    }
+
+    if (!d_delayAcknowledgement.isNull()) {
+        printer.printAttribute("delayAcknowledgement", 
+                               d_delayAcknowledgement.value());
+    }
+
+    if (!d_sendBufferSize.isNull()) {
+        printer.printAttribute("sendBufferSize", d_sendBufferSize.value());
+    }
+
+    if (!d_sendBufferLowWatermark.isNull()) {
+        printer.printAttribute("sendBufferLowWatermark",
+                               d_sendBufferLowWatermark.value());
+    }
+
+    if (!d_receiveBufferSize.isNull()) {
+        printer.printAttribute("receiveBufferSize", 
+                               d_receiveBufferSize.value());
+    }
+
+    if (!d_receiveBufferLowWatermark.isNull()) {
+        printer.printAttribute("receiveBufferLowWatermark",
+                               d_receiveBufferLowWatermark.value());
+    }
+
+    if (!d_debug.isNull()) {
+        printer.printAttribute("debug", d_debug.value());
+    }
+
+    if (!d_linger.isNull()) {
+        printer.printAttribute("linger", d_linger.value());
+    }
+
+    if (!d_broadcast.isNull()) {
+        printer.printAttribute("broadcast", d_broadcast.value());
+    }
+
+    if (!d_bypassRouting.isNull()) {
+        printer.printAttribute("bypassRouting", d_bypassRouting.value());
+    }
+
+    if (!d_inlineOutOfBandData.isNull()) {
+        printer.printAttribute("inlineOutOfBandData", 
+                               d_inlineOutOfBandData.value());
+    }
+
+    if (!d_timestampIncomingData.isNull()) {
+        printer.printAttribute("timestampIncomingData", 
+                               d_timestampIncomingData.value());
+    }
+
+    if (!d_timestampOutgoingData.isNull()) {
+        printer.printAttribute("timestampOutgoingData", 
+                               d_timestampOutgoingData.value());
+    }
+
+    if (!d_zeroCopy.isNull()) {
+        printer.printAttribute("zeroCopy", d_zeroCopy.value());
+    }
+
     printer.end();
     return stream;
 }

--- a/groups/nts/ntsa/ntsa_socketconfig.h
+++ b/groups/nts/ntsa/ntsa_socketconfig.h
@@ -44,18 +44,26 @@ namespace ntsa {
 /// That flag that indicates the operating system implementation should
 /// periodically emit transport-level "keep-alive" packets.
 ///
-/// @li @b  cork:
-/// TODO.
+/// @li @b cork:
+/// The flag that indicates that successive writes should be coalesced into the
+/// largest packets that can be formed. When set to true, this option indicates
+/// the user favors better network efficiency at the expense of worse latency.
+/// When set to false, this option indicates the user favors better latency at
+/// the expense of worse network efficiency.
 ///
 /// @li @b delayTransmission:
-/// The flag that indicates that subsequent writes should be coalesced into the
+/// The flag that indicates that successive writes should be coalesced into
 /// larger packets that would otherwise form. When set to true, this option
-/// indicates the user favors smaller latency at the expense of less network
-/// efficiency. When set to false, this option indicates the user favors
-/// greater network efficiency at the expense of greater latency.
+/// indicates the user favors better network efficiency at the expense of worse
+/// latency. When set to false, this option indicates the user favors better
+/// latency at the expense of worse network efficiency.
 ///
 /// @li @b delayAcknowledgement:
-/// TODO.
+/// The flag that indicates acknowledgement of successively-received packets
+/// should be coalesced. When set to true, this option indicates the user
+/// favors better network efficiency at the expense of worse latency. When set
+/// to false, this option indicates the user favors better latency at the
+/// expense of worse network efficiency.
 ///
 /// @li @b sendBufferSize:
 /// The maximum size of each socket send buffer. On some platforms, this
@@ -94,6 +102,16 @@ namespace ntsa {
 /// The flag that indicates out-of-band data should be placed into the normal
 /// data input queue.
 ///
+/// @li @b timestampIncomingData:
+/// The flag that indicates timestamps should be generated for outgoing data.
+///
+/// @li @b timestampOutgoingData:
+/// The flag that indicates timestamps should be generated for incoming data.
+///
+/// @li @b zeroCopy:
+/// The flag that indicates each send operation can request copy avoidance when
+/// enqueing data to the socket send buffer.
+///
 /// @par Thread Safety
 /// This class is not thread safe.
 ///
@@ -116,6 +134,7 @@ class SocketConfig
     bdlb::NullableValue<bool>         d_inlineOutOfBandData;
     bdlb::NullableValue<bool>         d_timestampIncomingData;
     bdlb::NullableValue<bool>         d_timestampOutgoingData;
+    bdlb::NullableValue<bool>         d_zeroCopy;
 
   public:
     /// Create new send options having the default value.
@@ -197,11 +216,18 @@ class SocketConfig
     /// the normal data input queue to the specified 'value'.
     void setInlineOutOfBandData(bool value);
 
-    /// Return the flag that indicates incoming data should be timestamped.
+    /// Set the flag that indicates incoming data should be timestamped to the
+    /// specified 'value'.
     void setTimestampIncomingData(bool value);
 
-    /// Set the flag that indicates outgoing data should be timestamped.
+    /// Set the flag that indicates outgoing data should be timestamped to the
+    /// specified 'value'.
     void setTimestampOutgoingData(bool value);
+
+    /// Set the flag that indicates each send operation can request copy
+    /// avoidance when enqueing data to the socket send buffer to the specified
+    /// 'value'.
+    void setZeroCopy(bool value);
 
     /// Load into the specified 'option' the option for the specified
     /// 'type'. Note that if the option for the 'type' is not set, the
@@ -266,6 +292,10 @@ class SocketConfig
 
     /// Return the flag that indicates outgoing data should be timestamped.
     const bdlb::NullableValue<bool>& timestampOutgoingData() const;
+
+    /// Return the flag that indicates each send operation can request copy
+    /// avoidance when enqueing data to the socket send buffer.
+    const bdlb::NullableValue<bool>& zeroCopy() const;
 
     /// Return true if this object has the same value as the specified
     /// 'other' object, otherwise return false.
@@ -345,6 +375,7 @@ SocketConfig::SocketConfig()
 , d_inlineOutOfBandData()
 , d_timestampIncomingData()
 , d_timestampOutgoingData()
+, d_zeroCopy()
 {
 }
 
@@ -366,6 +397,7 @@ SocketConfig::SocketConfig(const SocketConfig& original)
 , d_inlineOutOfBandData(original.d_inlineOutOfBandData)
 , d_timestampIncomingData(original.d_timestampIncomingData)
 , d_timestampOutgoingData(original.d_timestampOutgoingData)
+, d_zeroCopy(original.d_zeroCopy)
 {
 }
 
@@ -393,6 +425,7 @@ SocketConfig& SocketConfig::operator=(const SocketConfig& other)
     d_inlineOutOfBandData       = other.d_inlineOutOfBandData;
     d_timestampIncomingData     = other.d_timestampIncomingData;
     d_timestampOutgoingData     = other.d_timestampOutgoingData;
+    d_zeroCopy                  = other.d_zeroCopy;
 
     return *this;
 }
@@ -416,6 +449,7 @@ void SocketConfig::reset()
     d_inlineOutOfBandData.reset();
     d_timestampIncomingData.reset();
     d_timestampOutgoingData.reset();
+    d_zeroCopy.reset();
 }
 
 NTSCFG_INLINE
@@ -512,6 +546,12 @@ NTSCFG_INLINE
 void SocketConfig::setTimestampOutgoingData(bool value)
 {
     d_timestampOutgoingData = value;
+}
+
+NTSCFG_INLINE
+void SocketConfig::setZeroCopy(bool value)
+{
+    d_zeroCopy = value;
 }
 
 NTSCFG_INLINE
@@ -613,6 +653,12 @@ const bdlb::NullableValue<bool>& SocketConfig::timestampOutgoingData() const
 }
 
 NTSCFG_INLINE
+const bdlb::NullableValue<bool>& SocketConfig::zeroCopy() const
+{
+    return d_zeroCopy;
+}
+
+NTSCFG_INLINE
 bsl::ostream& operator<<(bsl::ostream& stream, const SocketConfig& object)
 {
     return object.print(stream, 0, -1);
@@ -657,6 +703,7 @@ void hashAppend(HASH_ALGORITHM& algorithm, const SocketConfig& value)
     hashAppend(algorithm, value.inlineOutOfBandData());
     hashAppend(algorithm, value.timestampIncomingData());
     hashAppend(algorithm, value.timestampOutgoingData());
+    hashAppend(algorithm, value.zeroCopy());
 }
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_socketoption.cpp
+++ b/groups/nts/ntsa/ntsa_socketoption.cpp
@@ -85,9 +85,9 @@ SocketOption::SocketOption(const SocketOption& other)
         new (d_timestampIncomingData.buffer()) bool(
             other.d_timestampIncomingData.object());
         break;
-    case ntsa::SocketOptionType::e_MSG_ZEROCOPY:
-        new (d_allowMsgZeroCopy.buffer()) bool(
-            other.d_allowMsgZeroCopy.object());
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        new (d_zeroCopy.buffer()) bool(
+            other.d_zeroCopy.object());
         break;
     default:
         BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_UNDEFINED);
@@ -160,9 +160,9 @@ SocketOption& SocketOption::operator=(const SocketOption& other)
         new (d_timestampOutgoingData.buffer()) bool(
             other.d_timestampOutgoingData.object());
         break;
-    case ntsa::SocketOptionType::e_MSG_ZEROCOPY:
-        new (d_allowMsgZeroCopy.buffer()) bool(
-            other.d_allowMsgZeroCopy.object());
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        new (d_zeroCopy.buffer()) bool(
+            other.d_zeroCopy.object());
         break;
     default:
         BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_UNDEFINED);
@@ -621,32 +621,32 @@ bool& SocketOption::makeTimestampOutgoingData(bool value)
     return d_timestampOutgoingData.object();
 }
 
-bool& SocketOption::makeAllowMsgZeroCopy()
+bool& SocketOption::makeZeroCopy()
 {
-    if (d_type == ntsa::SocketOptionType::e_MSG_ZEROCOPY) {
-        d_allowMsgZeroCopy.object() = false;
+    if (d_type == ntsa::SocketOptionType::e_ZERO_COPY) {
+        d_zeroCopy.object() = false;
     }
     else {
         this->reset();
-        new (d_allowMsgZeroCopy.buffer()) bool();
-        d_type = ntsa::SocketOptionType::e_MSG_ZEROCOPY;
+        new (d_zeroCopy.buffer()) bool();
+        d_type = ntsa::SocketOptionType::e_ZERO_COPY;
     }
 
-    return d_allowMsgZeroCopy.object();
+    return d_zeroCopy.object();
 }
 
-bool& SocketOption::makeAllowMsgZeroCopy(bool value)
+bool& SocketOption::makeZeroCopy(bool value)
 {
-    if (d_type == ntsa::SocketOptionType::e_MSG_ZEROCOPY) {
-        d_allowMsgZeroCopy.object() = value;
+    if (d_type == ntsa::SocketOptionType::e_ZERO_COPY) {
+        d_zeroCopy.object() = value;
     }
     else {
         this->reset();
-        new (d_allowMsgZeroCopy.buffer()) bool(value);
-        d_type = ntsa::SocketOptionType::e_MSG_ZEROCOPY;
+        new (d_zeroCopy.buffer()) bool(value);
+        d_type = ntsa::SocketOptionType::e_ZERO_COPY;
     }
 
-    return d_allowMsgZeroCopy.object();
+    return d_zeroCopy.object();
 }
 
 bool SocketOption::equals(const SocketOption& other) const
@@ -658,10 +658,48 @@ bool SocketOption::equals(const SocketOption& other) const
     switch (d_type) {
     case ntsa::SocketOptionType::e_REUSE_ADDRESS:
         return d_reuseAddress.object() == other.d_reuseAddress.object();
-        // TODO
+    case ntsa::SocketOptionType::e_KEEP_ALIVE:
+        return d_keepAlive.object() == other.d_keepAlive.object();
+    case ntsa::SocketOptionType::e_CORK:
+        return d_cork.object() == other.d_cork.object();
+    case ntsa::SocketOptionType::e_DELAY_TRANSMISSION:
+        return d_delayTransmission.object() == 
+               other.d_delayTransmission.object();
+    case ntsa::SocketOptionType::e_DELAY_ACKNOWLEDGEMENT:
+        return d_delayAcknowledgement.object() == 
+               other.d_delayAcknowledgement.object();
+    case ntsa::SocketOptionType::e_SEND_BUFFER_SIZE:
+        return d_sendBufferSize.object() == 
+               other.d_sendBufferSize.object();
+    case ntsa::SocketOptionType::e_SEND_BUFFER_LOW_WATERMARK:
+        return d_sendBufferLowWatermark.object() == 
+               other.d_sendBufferLowWatermark.object();
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE:
+        return d_receiveBufferSize.object() == 
+               other.d_receiveBufferSize.object();
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_LOW_WATERMARK:
+        return d_receiveBufferLowWatermark.object() == 
+               other.d_receiveBufferLowWatermark.object();
+    case ntsa::SocketOptionType::e_DEBUG:
+        return d_debug.object() == other.d_debug.object();
     case ntsa::SocketOptionType::e_LINGER:
         return d_linger.object().equals(other.d_linger.object());
-        // TODO
+    case ntsa::SocketOptionType::e_BROADCAST:
+        return d_broadcast.object() == other.d_broadcast.object();
+    case ntsa::SocketOptionType::e_BYPASS_ROUTING:
+        return d_bypassRouting.object() == other.d_bypassRouting.object();
+    case ntsa::SocketOptionType::e_INLINE_OUT_OF_BAND_DATA:
+        return d_inlineOutOfBandData.object() == 
+               other.d_inlineOutOfBandData.object();
+    case ntsa::SocketOptionType::e_RX_TIMESTAMPING:
+        return d_timestampIncomingData.object() == 
+               other.d_timestampIncomingData.object();
+    case ntsa::SocketOptionType::e_TX_TIMESTAMPING:
+        return d_timestampOutgoingData.object() == 
+               other.d_timestampOutgoingData.object();
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        return d_zeroCopy.object() == 
+               other.d_zeroCopy.object();
     default:
         return true;
     }
@@ -676,10 +714,47 @@ bool SocketOption::less(const SocketOption& other) const
     switch (d_type) {
     case ntsa::SocketOptionType::e_REUSE_ADDRESS:
         return d_reuseAddress.object() < other.d_reuseAddress.object();
-        // TODO
+    case ntsa::SocketOptionType::e_KEEP_ALIVE:
+        return d_keepAlive.object() < other.d_keepAlive.object();
+    case ntsa::SocketOptionType::e_CORK:
+        return d_cork.object() < other.d_cork.object();
+    case ntsa::SocketOptionType::e_DELAY_TRANSMISSION:
+        return d_delayTransmission.object() < 
+               other.d_delayTransmission.object();
+    case ntsa::SocketOptionType::e_DELAY_ACKNOWLEDGEMENT:
+        return d_delayAcknowledgement.object() < 
+               other.d_delayAcknowledgement.object();
+    case ntsa::SocketOptionType::e_SEND_BUFFER_SIZE:
+        return d_sendBufferSize.object() < 
+               other.d_sendBufferSize.object();
+    case ntsa::SocketOptionType::e_SEND_BUFFER_LOW_WATERMARK:
+        return d_sendBufferLowWatermark.object() < 
+               other.d_sendBufferLowWatermark.object();
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE:
+        return d_receiveBufferSize.object() < 
+               other.d_receiveBufferSize.object();
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_LOW_WATERMARK:
+        return d_receiveBufferLowWatermark.object() < 
+               other.d_receiveBufferLowWatermark.object();
+    case ntsa::SocketOptionType::e_DEBUG:
+        return d_debug.object() < other.d_debug.object();
     case ntsa::SocketOptionType::e_LINGER:
         return d_linger.object().less(other.d_linger.object());
-        // TODO
+    case ntsa::SocketOptionType::e_BROADCAST:
+        return d_broadcast.object() < other.d_broadcast.object();
+    case ntsa::SocketOptionType::e_BYPASS_ROUTING:
+        return d_bypassRouting.object() < other.d_bypassRouting.object();
+    case ntsa::SocketOptionType::e_INLINE_OUT_OF_BAND_DATA:
+        return d_inlineOutOfBandData.object() < 
+               other.d_inlineOutOfBandData.object();
+    case ntsa::SocketOptionType::e_RX_TIMESTAMPING:
+        return d_timestampIncomingData.object() < 
+               other.d_timestampIncomingData.object();
+    case ntsa::SocketOptionType::e_TX_TIMESTAMPING:
+        return d_timestampOutgoingData.object() < 
+               other.d_timestampOutgoingData.object();
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        return d_zeroCopy.object() < other.d_zeroCopy.object();
     default:
         return true;
     }
@@ -693,11 +768,54 @@ bsl::ostream& SocketOption::print(bsl::ostream& stream,
     case ntsa::SocketOptionType::e_REUSE_ADDRESS:
         stream << d_reuseAddress.object();
         break;
-        // TODO
+    case ntsa::SocketOptionType::e_KEEP_ALIVE:
+        stream << d_keepAlive.object();
+        break;
+    case ntsa::SocketOptionType::e_CORK:
+        stream << d_cork.object();
+        break;
+    case ntsa::SocketOptionType::e_DELAY_TRANSMISSION:
+        stream << d_delayTransmission.object();
+        break;
+    case ntsa::SocketOptionType::e_DELAY_ACKNOWLEDGEMENT:
+        stream << d_delayAcknowledgement.object();
+        break;
+    case ntsa::SocketOptionType::e_SEND_BUFFER_SIZE:
+        stream << d_sendBufferSize.object();
+        break;
+    case ntsa::SocketOptionType::e_SEND_BUFFER_LOW_WATERMARK:
+        stream << d_sendBufferLowWatermark.object();
+        break;
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_SIZE:
+        stream << d_receiveBufferSize.object();
+        break;
+    case ntsa::SocketOptionType::e_RECEIVE_BUFFER_LOW_WATERMARK:
+        stream << d_receiveBufferLowWatermark.object();
+        break;
+    case ntsa::SocketOptionType::e_DEBUG:
+        stream << d_debug.object();
+        break;
     case ntsa::SocketOptionType::e_LINGER:
         d_linger.object().print(stream, level, spacesPerLevel);
         break;
-        // TODO
+    case ntsa::SocketOptionType::e_BROADCAST:
+        stream << d_broadcast.object();
+        break;
+    case ntsa::SocketOptionType::e_BYPASS_ROUTING:
+        stream << d_bypassRouting.object();
+        break;
+    case ntsa::SocketOptionType::e_INLINE_OUT_OF_BAND_DATA:
+        stream << d_inlineOutOfBandData.object();
+        break;
+    case ntsa::SocketOptionType::e_RX_TIMESTAMPING:
+        stream << d_timestampIncomingData.object();
+        break;
+    case ntsa::SocketOptionType::e_TX_TIMESTAMPING:
+        stream << d_timestampOutgoingData.object();
+        break;
+    case ntsa::SocketOptionType::e_ZERO_COPY:
+        stream << d_zeroCopy.object();
+        break;
     default:
         BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_UNDEFINED);
         stream << "UNDEFINED";

--- a/groups/nts/ntsa/ntsa_socketoption.h
+++ b/groups/nts/ntsa/ntsa_socketoption.h
@@ -35,9 +35,88 @@ namespace ntsa {
 /// Provide a union of socket options.
 ///
 /// @details
-/// Provide a value-semantic type that represents a discriminated
-/// union of socket options.
-//
+/// Provide a value-semantic type that represents a discriminated union of 
+/// socket options.
+///
+/// @par Attributes
+/// This class is composed of the following attributes.
+///
+/// @li @b reuseAddress:
+/// The flag that indicates the operating system should allow the user to
+/// rebind a socket to reuse local addresses.
+///
+/// @li @b keepAlive:
+/// That flag that indicates the operating system implementation should
+/// periodically emit transport-level "keep-alive" packets.
+///
+/// @li @b cork:
+/// The flag that indicates that successive writes should be coalesced into the
+/// largest packets that can be formed. When set to true, this option indicates
+/// the user favors better network efficiency at the expense of worse latency.
+/// When set to false, this option indicates the user favors better latency at
+/// the expense of worse network efficiency.
+///
+/// @li @b delayTransmission:
+/// The flag that indicates that successive writes should be coalesced into
+/// larger packets that would otherwise form. When set to true, this option
+/// indicates the user favors better network efficiency at the expense of worse
+/// latency. When set to false, this option indicates the user favors better
+/// latency at the expense of worse network efficiency.
+///
+/// @li @b delayAcknowledgement:
+/// The flag that indicates acknowledgement of successively-received packets
+/// should be coalesced. When set to true, this option indicates the user
+/// favors better network efficiency at the expense of worse latency. When set
+/// to false, this option indicates the user favors better latency at the
+/// expense of worse network efficiency.
+///
+/// @li @b sendBufferSize:
+/// The maximum size of each socket send buffer. On some platforms, this
+/// options may serve simply as a hint.
+///
+/// @li @b sendBufferLowWatermark:
+/// The amount of available capacity that must exist in the socket send buffer
+/// for the operating system to indicate the socket is writable.
+///
+/// @li @b receiveBufferSize:
+/// The maximum size of each socket receive buffer. On some platforms, this
+/// options may serve simply as a hint.
+///
+/// @li @b receiveBufferLowWatermark:
+/// The amount of available data that must exist in the socket receive buffer
+/// for the operating system to indicate the socket is readable.
+///
+/// @li @b debug:
+/// This flag indicates that each socket should be put into debug mode in the
+/// operating system. The support and meaning of this option is
+/// platform-specific.
+///
+/// @li @b linger:
+/// The options that control whether the operating system should gracefully
+/// attempt to transmit any data remaining in the socket send buffer before
+/// closing the connection.
+///
+/// @li @b broadcast:
+/// The flag that indicates the socket supports sending to a broadcast address.
+///
+/// @li @b bypassRouting:
+/// The flag that indicates that normal routing rules are not used, the route
+/// is based upon the destination address only.
+///
+/// @li @b inlineOutOfBandData:
+/// The flag that indicates out-of-band data should be placed into the normal
+/// data input queue.
+///
+/// @li @b timestampIncomingData:
+/// The flag that indicates timestamps should be generated for outgoing data.
+///
+/// @li @b timestampOutgoingData:
+/// The flag that indicates timestamps should be generated for incoming data.
+///
+/// @li @b zeroCopy:
+/// The flag that indicates each send operation can request copy avoidance when
+/// enqueing data to the socket send buffer.
+///
 /// @par Thread Safety
 /// This class is not thread safe.
 ///
@@ -61,7 +140,7 @@ class SocketOption
         bsls::ObjectBuffer<bool>         d_inlineOutOfBandData;
         bsls::ObjectBuffer<bool>         d_timestampIncomingData;
         bsls::ObjectBuffer<bool>         d_timestampOutgoingData;
-        bsls::ObjectBuffer<bool>         d_allowMsgZeroCopy;
+        bsls::ObjectBuffer<bool>         d_zeroCopy;
     };
 
     ntsa::SocketOptionType::Value d_type;
@@ -77,97 +156,88 @@ class SocketOption
     /// Destroy this object.
     ~SocketOption();
 
-    /// Assign the value of the specified 'other' object to this object.
-    /// Return a reference to this modifiable object.
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
     SocketOption& operator=(const SocketOption& other);
 
-    /// Reset the value of this object to its value upon default
-    /// construction.
+    /// Reset the value of this object to its value upon default construction.
     void reset();
 
     /// Select the "reuseAddress" representation. Return a reference to the
     /// modifiable representation.
     bool& makeReuseAddress();
 
-    /// Select the "reuseAddress" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "reuseAddress" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
     bool& makeReuseAddress(bool value);
 
     /// Select the "keepAlive" representation. Return a reference to the
     /// modifiable representation.
     bool& makeKeepAlive();
 
-    /// Select the "keepAlive" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "keepAlive" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
     bool& makeKeepAlive(bool value);
 
-    /// Select the "cork" representation. Return a reference to the
-    /// modifiable representation.
+    /// Select the "cork" representation. Return a reference to the modifiable
+    /// representation.
     bool& makeCork();
 
-    /// Select the "cork" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "cork" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
     bool& makeCork(bool value);
 
-    /// Select the "delayTransmission" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "delayTransmission" representation. Return a reference to
+    /// the modifiable representation.
     bool& makeDelayTransmission();
 
     /// Select the "delayTransmission" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeDelayTransmission(bool value);
 
-    /// Select the "delayAcknowledgement" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "delayAcknowledgement" representation. Return a reference to
+    /// the modifiable representation.
     bool& makeDelayAcknowledgement();
 
-    /// Select the "delayAcknowledgement" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "delayAcknowledgement" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeDelayAcknowledgement(bool value);
 
-    /// Select the "sendBufferSize" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "sendBufferSize" representation. Return a reference to the
+    /// modifiable representation.
     bsl::size_t& makeSendBufferSize();
 
-    /// Select the "sendBufferSize" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "sendBufferSize" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bsl::size_t& makeSendBufferSize(bsl::size_t value);
 
-    /// Select the "sendBufferLowWatermark" representation. Return a
-    /// reference to the modifiable representation.
+    /// Select the "sendBufferLowWatermark" representation. Return a reference
+    /// to the modifiable representation.
     bsl::size_t& makeSendBufferLowWatermark();
 
-    /// Select the "sendBufferLowWatermark" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "sendBufferLowWatermark" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bsl::size_t& makeSendBufferLowWatermark(bsl::size_t value);
 
-    /// Select the "receiveBufferSize" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "receiveBufferSize" representation. Return a reference to
+    /// the modifiable representation.
     bsl::size_t& makeReceiveBufferSize();
 
-    /// Select the "receiveBufferSize" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// Select the "receiveBufferSize" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bsl::size_t& makeReceiveBufferSize(bsl::size_t value);
 
     /// Select the "receiveBufferLowWatermark" representation. Return a
     /// reference to the modifiable representation.
     bsl::size_t& makeReceiveBufferLowWatermark();
 
-    /// Select the "receiveBufferLowWatermark" representation initially
-    /// having the specified 'value'. Return a reference to the modifiable
+    /// Select the "receiveBufferLowWatermark" representation initially having
+    /// the specified 'value'. Return a reference to the modifiable
     /// representation.
     bsl::size_t& makeReceiveBufferLowWatermark(bsl::size_t value);
 
-    /// Select the "debug" representation. Return a reference to the
-    /// modifiable representation.
+    /// Select the "debug" representation. Return a reference to the modifiable
+    /// representation.
     bool& makeDebug();
 
     /// Select the "debug" representation initially having the specified
@@ -195,26 +265,23 @@ class SocketOption
     bool& makeBypassRouting();
 
     /// Select the "bypassRouting" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeBypassRouting(bool value);
 
-    /// Select the "inlineOutOfBandData" representation. Return a reference
-    /// to the modifiable representation.
+    /// Select the "inlineOutOfBandData" representation. Return a reference to
+    /// the modifiable representation.
     bool& makeInlineOutOfBandData();
 
     /// Select the "inlineOutOfBandData" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable
-    /// representation.
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeInlineOutOfBandData(bool value);
 
-    /// Select the "timestampIncomingData" representation. Return a
-    /// reference to the modifiable representation.
+    /// Select the "timestampIncomingData" representation. Return a reference
+    /// to the modifiable representation.
     bool& makeTimestampIncomingData();
 
-    /// Select the "timestampIncomingData" representation initially having
-    /// the specified 'value'. Return a reference to the modifiable
-    /// representation
+    /// Select the "timestampIncomingData" representation initially having the
+    /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeTimestampIncomingData(bool value);
 
     /// Select the "timestampOutgoingData" representation. Return a reference
@@ -225,24 +292,24 @@ class SocketOption
     /// specified 'value'. Return a reference to the modifiable representation.
     bool& makeTimestampOutgoingData(bool value);
 
-    /// Select the "allowMsgZeroCopy" representation. Return a reference
-    /// to the modifiable representation.
-    bool& makeAllowMsgZeroCopy();
+    /// Select the "zeroCopy" representation. Return a reference to the
+    /// modifiable representation.
+    bool& makeZeroCopy();
 
-    /// Select the "allowMsgZeroCopy" representation initially having the
-    /// specified 'value'. Return a reference to the modifiable representation.
-    bool& makeAllowMsgZeroCopy(bool value);
+    /// Select the "zeroCopy" representation initially having the specified
+    /// 'value'. Return a reference to the modifiable representation.
+    bool& makeZeroCopy(bool value);
 
-    /// Return a reference to the modifiable "reuseAddress" representation.
-    /// The behavior is undefined unless 'isReuseAddress()' is true.
+    /// Return a reference to the modifiable "reuseAddress" representation. The
+    /// behavior is undefined unless 'isReuseAddress()' is true.
     bool& reuseAddress();
 
-    /// Return a reference to the modifiable "keepAlive" representation.
-    /// The behavior is undefined unless 'isKeepAlive()' is true.
+    /// Return a reference to the modifiable "keepAlive" representation. The
+    /// behavior is undefined unless 'isKeepAlive()' is true.
     bool& keepAlive();
 
-    /// Return a reference to the modifiable "cork" representation.
-    /// The behavior is undefined unless 'isCork()' is true.
+    /// Return a reference to the modifiable "cork" representation. The
+    /// behavior is undefined unless 'isCork()' is true.
     bool& cork();
 
     /// Return a reference to the modifiable "delayTransmission"
@@ -255,9 +322,8 @@ class SocketOption
     /// 'isDelayAcknowledgement()' is true.
     bool& delayAcknowledgement();
 
-    /// Return a reference to the modifiable "sendBufferSize"
-    /// representation. The behavior is undefined unless
-    /// 'isSendBufferSize()' is true.
+    /// Return a reference to the modifiable "sendBufferSize" representation.
+    /// The behavior is undefined unless 'isSendBufferSize()' is true.
     bsl::size_t& sendBufferSize();
 
     /// Return a reference to the modifiable "sendBufferLowWatermark"
@@ -275,16 +341,16 @@ class SocketOption
     /// 'isReceiveBufferLowWatermark()' is true.
     bsl::size_t& receiveBufferLowWatermark();
 
-    /// Return a reference to the modifiable "debug" representation.
-    /// The behavior is undefined unless 'isDebug()' is true.
+    /// Return a reference to the modifiable "debug" representation. The
+    /// behavior is undefined unless 'isDebug()' is true.
     bool& debug();
 
-    /// Return a reference to the modifiable "linger" representation.
-    /// The behavior is undefined unless 'isLinger()' is true.
+    /// Return a reference to the modifiable "linger" representation. The
+    /// behavior is undefined unless 'isLinger()' is true.
     ntsa::Linger& linger();
 
-    /// Return a reference to the modifiable "broadcast" representation.
-    /// The behavior is undefined unless 'isBroadcast()' is true.
+    /// Return a reference to the modifiable "broadcast" representation. The
+    /// behavior is undefined unless 'isBroadcast()' is true.
     bool& broadcast();
 
     /// Return a reference to the modifiable "bypassRouting" representation.
@@ -306,16 +372,16 @@ class SocketOption
     /// 'isTimestampOutOutgoingData()' is true.
     bool& timestampOutgoingData();
 
-    /// Return a reference to the modifiable "allowMsgZeroCopy" representation.
-    /// The behavior is undefined unless 'isAllowMsgZeroCopy()' is true.
-    bool& allowMsgZeroCopy();
+    /// Return a reference to the modifiable "zeroCopy" representation. The
+    /// behavior is undefined unless 'isZeroCopy()' is true.
+    bool& zeroCopy();
 
-    /// Return the non-modifiable "reuseAddress" representation. The
-    /// behavior is undefined unless 'isReuseAddress()' is true.
+    /// Return the non-modifiable "reuseAddress" representation. The behavior
+    /// is undefined unless 'isReuseAddress()' is true.
     bool reuseAddress() const;
 
-    /// Return the non-modifiable "keepAlive" representation. The behavior
-    /// is undefined unless 'isKeepAlive()' is true.
+    /// Return the non-modifiable "keepAlive" representation. The behavior is
+    /// undefined unless 'isKeepAlive()' is true.
     bool keepAlive() const;
 
     /// Return the non-modifiable "cork" representation. The behavior is
@@ -330,66 +396,64 @@ class SocketOption
     /// behavior is undefined unless 'isDelayAcknowledgement()' is true.
     bool delayAcknowledgement() const;
 
-    /// Return the non-modifiable "sendBufferSize" representation. The
-    /// behavior is undefined unless 'isSendBufferSize()' is true.
+    /// Return the non-modifiable "sendBufferSize" representation. The behavior
+    /// is undefined unless 'isSendBufferSize()' is true.
     bsl::size_t sendBufferSize() const;
 
-    /// Return the non-modifiable "sendBufferLowWatermark" representation.
-    /// The behavior is undefined unless 'isSendBufferLowWatermark()' is
-    /// true.
+    /// Return the non-modifiable "sendBufferLowWatermark" representation. The
+    /// behavior is undefined unless 'isSendBufferLowWatermark()' is true.
     bsl::size_t sendBufferLowWatermark() const;
 
     /// Return the non-modifiable "receiveBufferSize" representation. The
     /// behavior is undefined unless 'isReceiveBufferSize()' is true.
     bsl::size_t receiveBufferSize() const;
 
-    /// Return the non-modifiable "receiveBufferLowWatermark"
-    /// representation. The behavior is undefined unless
-    /// 'isReceiveBufferLowWatermark()' is true.
+    /// Return the non-modifiable "receiveBufferLowWatermark" representation.
+    /// The behavior is undefined unless 'isReceiveBufferLowWatermark()' is
+    /// true.
     bsl::size_t receiveBufferLowWatermark() const;
 
     /// Return the non-modifiable "debug" representation. The behavior is
     /// undefined unless 'isDebug()' is true.
     bool debug() const;
 
-    /// Return a reference to the non-modifiable "linger" representation.
-    /// The behavior is undefined unless 'isLinger()' is true.
+    /// Return a reference to the non-modifiable "linger" representation. The
+    /// behavior is undefined unless 'isLinger()' is true.
     const ntsa::Linger& linger() const;
 
-    /// Return the non-modifiable "broadcast" representation. The behavior
-    /// is undefined unless 'isBroadcast()' is true.
+    /// Return the non-modifiable "broadcast" representation. The behavior is
+    /// undefined unless 'isBroadcast()' is true.
     bool broadcast() const;
 
-    /// Return the non-modifiable "bypassRouting" representation. The
-    /// behavior is undefined unless 'isBypassRouting()' is true.
+    /// Return the non-modifiable "bypassRouting" representation. The behavior
+    /// is undefined unless 'isBypassRouting()' is true.
     bool bypassRouting() const;
 
     /// Return the non-modifiable "inlineOutOfBandData" representation. The
     /// behavior is undefined unless 'isInlineOutOfBandData()' is true.
     bool inlineOutOfBandData() const;
 
-    /// Return the non-modifiable "timestampIncomingData" representation.
-    /// The behavior is undefined unless 'isTimestampIncomingData()' is
-    /// true.
+    /// Return the non-modifiable "timestampIncomingData" representation. The
+    /// behavior is undefined unless 'isTimestampIncomingData()' is true.
     bool timestampIncomingData() const;
 
     /// Return the non-modifiable "timestampOutgoingData" representation. The
     /// behavior is undefined unless 'isTimestampOutgoingData()' is true.
     bool timestampOutgoingData() const;
 
-    /// Return the non-modifiable "allowMsgZeroCopy" representation. The
-    /// behavior is undefined unless 'isAllowMsgZeroCopy()' is true.
-    bool allowMsgZeroCopy() const;
+    /// Return the non-modifiable "zeroCopy" representation. The behavior is
+    /// undefined unless 'isZeroCopy()' is true.
+    bool zeroCopy() const;
 
     /// Return the type of the option representation.
     enum ntsa::SocketOptionType::Value type() const;
 
-    /// Return true if the option representation is undefined, otherwise
-    /// return false.
+    /// Return true if the option representation is undefined, otherwise return
+    /// false.
     bool isUndefined() const;
 
-    /// Return true if the "reuseAddress" representation is currently
-    /// selected, otherwise return false.
+    /// Return true if the "reuseAddress" representation is currently selected,
+    /// otherwise return false.
     bool isReuseAddress() const;
 
     /// Return true if the "keepAlive" representation is currently selected,
@@ -412,8 +476,8 @@ class SocketOption
     /// selected, otherwise return false.
     bool isSendBufferSize() const;
 
-    /// Return true if the "sendBufferLowWatermark" representation is
-    /// currently selected, otherwise return false.
+    /// Return true if the "sendBufferLowWatermark" representation is currently
+    /// selected, otherwise return false.
     bool isSendBufferLowWatermark() const;
 
     /// Return true if the "receiveBufferSize" representation is currently
@@ -452,41 +516,40 @@ class SocketOption
     /// selected, otherwise return false.
     bool isTimestampOutgoingData() const;
 
-    /// Return true if the "allowMsgZeroCopy" representation is currently
-    /// selected, otherwise return false.
-    bool isAllowMsgZeroCopy() const;
+    /// Return true if the "zeroCopy" representation is currently selected,
+    /// otherwise return false.
+    bool isZeroCopy() const;
 
-    /// Return true if this object has the same value as the specified
-    /// 'other' object, otherwise return false.
+    /// Return true if this object has the same value as the specified 'other'
+    /// object, otherwise return false.
     bool equals(const SocketOption& other) const;
 
-    /// Return true if the value of this object is less than the value of
-    /// the specified 'other' object, otherwise return false.
+    /// Return true if the value of this object is less than the value of the
+    /// specified 'other' object, otherwise return false.
     bool less(const SocketOption& other) const;
 
-    /// Format this object to the specified output 'stream' at the
-    /// optionally specified indentation 'level' and return a reference to
-    /// the modifiable 'stream'.  If 'level' is specified, optionally
-    /// specify 'spacesPerLevel', the number of spaces per indentation level
-    /// for this and all of its nested objects.  Each line is indented by
-    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    /// negative, suppress indentation of the first line.  If
-    /// 'spacesPerLevel' is negative, suppress line breaks and format the
-    /// entire output on one line.  If 'stream' is initially invalid, this
-    /// operation has no effect.  Note that a trailing newline is provided
-    /// in multiline mode only.
+    /// Format this object to the specified output 'stream' at the optionally
+    /// specified indentation 'level' and return a reference to the modifiable
+    /// 'stream'.  If 'level' is specified, optionally specify
+    /// 'spacesPerLevel', the number of spaces per indentation level for this
+    /// and all of its nested objects.  Each line is indented by the absolute
+    /// value of 'level * spacesPerLevel'.  If 'level' is negative, suppress
+    /// indentation of the first line.  If 'spacesPerLevel' is negative,
+    /// suppress line breaks and format the entire output on one line.  If
+    /// 'stream' is initially invalid, this operation has no effect.  Note that
+    /// a trailing newline is provided in multiline mode only.
     bsl::ostream& print(bsl::ostream& stream,
                         int           level          = 0,
                         int           spacesPerLevel = 4) const;
 
-    /// Defines the traits of this type. These traits can be used to select,
-    /// at compile-time, the most efficient algorithm to manipulate objects
-    /// of this type.
+    /// Defines the traits of this type. These traits can be used to select, at
+    /// compile-time, the most efficient algorithm to manipulate objects of
+    /// this type.
     NTSCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(SocketOption);
 };
 
-/// Write the specified 'object' to the specified 'stream'. Return a
-/// modifiable reference to the 'stream'.
+/// Write the specified 'object' to the specified 'stream'. Return a modifiable
+/// reference to the 'stream'.
 ///
 /// @related ntsa::SocketOption
 bsl::ostream& operator<<(bsl::ostream& stream, const SocketOption& object);
@@ -503,8 +566,8 @@ bool operator==(const SocketOption& lhs, const SocketOption& rhs);
 /// @related ntsa::SocketOption
 bool operator!=(const SocketOption& lhs, const SocketOption& rhs);
 
-/// Contribute the values of the salient attributes of the specified 'value'
-/// to the specified hash 'algorithm'.
+/// Contribute the values of the salient attributes of the specified 'value' to
+/// the specified hash 'algorithm'.
 ///
 /// @related ntsa::SocketOption
 template <typename HASH_ALGORITHM>
@@ -641,10 +704,10 @@ bool& SocketOption::timestampOutgoingData()
 }
 
 NTSCFG_INLINE
-bool& SocketOption::allowMsgZeroCopy()
+bool& SocketOption::zeroCopy()
 {
-    BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_MSG_ZEROCOPY);
-    return d_allowMsgZeroCopy.object();
+    BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_ZERO_COPY);
+    return d_zeroCopy.object();
 }
 
 NTSCFG_INLINE
@@ -761,10 +824,10 @@ bool SocketOption::timestampOutgoingData() const
 }
 
 NTSCFG_INLINE
-bool SocketOption::allowMsgZeroCopy() const
+bool SocketOption::zeroCopy() const
 {
-    BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_MSG_ZEROCOPY);
-    return d_allowMsgZeroCopy.object();
+    BSLS_ASSERT(d_type == ntsa::SocketOptionType::e_ZERO_COPY);
+    return d_zeroCopy.object();
 }
 
 NTSCFG_INLINE
@@ -876,9 +939,9 @@ bool SocketOption::isTimestampOutgoingData() const
 }
 
 NTSCFG_INLINE
-bool SocketOption::isAllowMsgZeroCopy() const
+bool SocketOption::isZeroCopy() const
 {
-    return (d_type == ntsa::SocketOptionType::e_MSG_ZEROCOPY);
+    return (d_type == ntsa::SocketOptionType::e_ZERO_COPY);
 }
 
 NTSCFG_INLINE
@@ -958,8 +1021,8 @@ void hashAppend(HASH_ALGORITHM& algorithm, const SocketOption& value)
     else if (value.isTimestampOutgoingData()) {
         hashAppend(algorithm, value.timestampOutgoingData());
     }
-    else if (value.isAllowMsgZeroCopy()) {
-        hashAppend(algorithm, value.allowMsgZeroCopy());
+    else if (value.isZeroCopy()) {
+        hashAppend(algorithm, value.zeroCopy());
     }
 }
 

--- a/groups/nts/ntsa/ntsa_socketoption.t.cpp
+++ b/groups/nts/ntsa/ntsa_socketoption.t.cpp
@@ -88,24 +88,24 @@ NTSCFG_TEST_CASE(3)
     // Concern: test allowMsgZeroCopy option
 
     ntsa::SocketOption so;
-    NTSCFG_TEST_FALSE(so.isAllowMsgZeroCopy());
+    NTSCFG_TEST_FALSE(so.isZeroCopy());
 
-    so.makeAllowMsgZeroCopy(true);
-    NTSCFG_TEST_TRUE(so.isAllowMsgZeroCopy());
+    so.makeZeroCopy(true);
+    NTSCFG_TEST_TRUE(so.isZeroCopy());
 
-    bool& val = so.allowMsgZeroCopy();
+    bool& val = so.zeroCopy();
     NTSCFG_TEST_TRUE(val);
     val = false;
-    NTSCFG_TEST_FALSE(so.allowMsgZeroCopy());
+    NTSCFG_TEST_FALSE(so.zeroCopy());
 
     val = true;
-    NTSCFG_TEST_TRUE(so.allowMsgZeroCopy());
+    NTSCFG_TEST_TRUE(so.zeroCopy());
 
-    so.makeAllowMsgZeroCopy();
-    NTSCFG_TEST_FALSE(so.allowMsgZeroCopy());
+    so.makeZeroCopy();
+    NTSCFG_TEST_FALSE(so.zeroCopy());
 
     so.reset();
-    NTSCFG_TEST_FALSE(so.isAllowMsgZeroCopy());
+    NTSCFG_TEST_FALSE(so.isZeroCopy());
 }
 
 NTSCFG_TEST_DRIVER

--- a/groups/nts/ntsa/ntsa_socketoptiontype.cpp
+++ b/groups/nts/ntsa/ntsa_socketoptiontype.cpp
@@ -43,7 +43,7 @@ int SocketOptionType::fromInt(SocketOptionType::Value* result, int number)
     case SocketOptionType::e_INLINE_OUT_OF_BAND_DATA:
     case SocketOptionType::e_RX_TIMESTAMPING:
     case SocketOptionType::e_TX_TIMESTAMPING:
-    case SocketOptionType::e_MSG_ZEROCOPY:
+    case SocketOptionType::e_ZERO_COPY:
         *result = static_cast<SocketOptionType::Value>(number);
         return 0;
     default:
@@ -123,8 +123,8 @@ int SocketOptionType::fromString(SocketOptionType::Value* result,
         *result = e_TX_TIMESTAMPING;
         return 0;
     }
-    if (bdlb::String::areEqualCaseless(string, "MSG_ZEROCOPY")) {
-        *result = e_MSG_ZEROCOPY;
+    if (bdlb::String::areEqualCaseless(string, "ZERO_COPY")) {
+        *result = e_ZERO_COPY;
         return 0;
     }
 
@@ -185,8 +185,8 @@ const char* SocketOptionType::toString(SocketOptionType::Value value)
     case e_TX_TIMESTAMPING: {
         return "TX_TIMESTAMPING";
     } break;
-    case e_MSG_ZEROCOPY: {
-        return "MSG_ZEROCOPY";
+    case e_ZERO_COPY: {
+        return "ZERO_COPY";
     } break;
     }
 

--- a/groups/nts/ntsa/ntsa_socketoptiontype.h
+++ b/groups/nts/ntsa/ntsa_socketoptiontype.h
@@ -86,15 +86,15 @@ struct SocketOptionType {
         /// Place out-of-band data into the normal incoming data stream.
         e_INLINE_OUT_OF_BAND_DATA = 14,
 
-        /// This option type allows to enable or disable receive timestamps.
+        /// Generate timestamps for incoming data.
         e_RX_TIMESTAMPING = 15,
 
-        /// This option type allows to enable or disable transmit timestamps.
+        /// Generate timestamps for outgoing data.
         e_TX_TIMESTAMPING = 16,
 
-        /// This option type allows or forbids usage of Linux MSG_ZEROCOPY
-        /// mechanism
-        e_MSG_ZEROCOPY = 17
+        /// Allow each send operation to request copy avoidance when enqueing
+        /// data to the socket send buffer.
+        e_ZERO_COPY = 17
     };
 
     /// Return the string representation exactly matching the enumerator

--- a/groups/nts/ntsa/ntsa_timestamp.h
+++ b/groups/nts/ntsa/ntsa_timestamp.h
@@ -19,30 +19,29 @@
 #include <bsls_ident.h>
 BSLS_IDENT("$Id: $")
 
+#include <ntscfg_platform.h>
 #include <ntsscm_version.h>
-
+#include <ntsa_timestamptype.h>
 #include <bslh_hash.h>
 #include <bsls_timeinterval.h>
-
-#include <ntsa_timestamptype.h>
 
 namespace BloombergLP {
 namespace ntsa {
 
-/// Provide a type holding a transmit timestamp.
-///
-/// @details
-/// Provide a value-semantic type that holds a timestamp.
+/// Describe a notification of a timestamp of outgoing data.
 ///
 /// @par Attributes
-/// This class is composed of the following attributes..
+/// This class is composed of the following attributes.
 ///
 /// @li @b type:
-/// Type of the timestamp. It describes source of the timestamp. Default value
-/// is e_UNDEFINED.
+/// The type of the timestamp, indicating where the timestamp was measured in
+/// the transmission and acknowledgement process.
+///
+/// @li @b id:
+/// The data identifier.
 ///
 /// @li @b time:
-/// The timestamp value. Default value is 0.
+/// The timestamp, in absolute time since the Unix epoch.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -56,54 +55,54 @@ class Timestamp
     /// Create new timestamp having the default value.
     Timestamp();
 
-    /// Create new timestamp having the same value as the specified
-    /// 'original' object.
+    /// Create new timestamp having the same value as the specified 'original'
+    /// object.
     Timestamp(const Timestamp& original);
 
     /// Destroy this object.
     ~Timestamp();
 
-    /// Assign the value of the specified 'other' object to this object.
-    /// Return a reference to this modifiable object.
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
     Timestamp& operator=(const Timestamp& other);
 
-    /// Set timestamp type to the specifued 'value'.
+    /// Set the timestamp type to the specified 'value'.
     void setType(ntsa::TimestampType::Value value);
 
-    /// Set id of the timestamp to the specified 'value'.
+    /// Set the identifier of the data for which the timestamp applies to the
+    /// specified 'value'.
     void setId(bsl::uint32_t value);
 
-    /// Set timestamp time to the specified 'value'.
+    /// Set the timestamp time to the specified 'value'.
     void setTime(const bsls::TimeInterval& value);
 
-    /// Return type of the timestamp.
+    /// Return the type of the timestamp.
     ntsa::TimestampType::Value type() const;
 
-    /// Get id of the timestamp.
+    /// Return the identifier of the data to which the timestamp applies.
     bsl::uint32_t id() const;
 
-    /// Return time of the timestamp.
+    /// Return time of the timestamp, in absolute time since the Unix epoch.
     const bsls::TimeInterval& time() const;
 
-    /// Return true if this object has the same value as the specified
-    /// 'other' object, otherwise return false.
+    /// Return true if this object has the same value as the specified 'other'
+    /// object, otherwise return false.
     bool equals(const Timestamp& other) const;
 
-    /// Return true if the value of this object is less than the value of
-    /// the specified 'other' object, otherwise return false.
+    /// Return true if the value of this object is less than the value of the
+    /// specified 'other' object, otherwise return false.
     bool less(const Timestamp& other) const;
 
-    /// Format this object to the specified output 'stream' at the
-    /// optionally specified indentation 'level' and return a reference to
-    /// the modifiable 'stream'.  If 'level' is specified, optionally
-    /// specify 'spacesPerLevel', the number of spaces per indentation level
-    /// for this and all of its nested objects.  Each line is indented by
-    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    /// negative, suppress indentation of the first line.  If
-    /// 'spacesPerLevel' is negative, suppress line breaks and format the
-    /// entire output on one line.  If 'stream' is initially invalid, this
-    /// operation has no effect.  Note that a trailing newline is provided
-    /// in multiline mode only.
+    /// Format this object to the specified output 'stream' at the optionally
+    /// specified indentation 'level' and return a reference to the modifiable
+    /// 'stream'.  If 'level' is specified, optionally specify
+    /// 'spacesPerLevel', the number of spaces per indentation level for this
+    /// and all of its nested objects.  Each line is indented by the absolute
+    /// value of 'level * spacesPerLevel'.  If 'level' is negative, suppress
+    /// indentation of the first line.  If 'spacesPerLevel' is negative,
+    /// suppress line breaks and format the entire output on one line.  If
+    /// 'stream' is initially invalid, this operation has no effect.  Note that
+    /// a trailing newline is provided in multiline mode only.
     bsl::ostream& print(bsl::ostream& stream,
                         int           level          = 0,
                         int           spacesPerLevel = 4) const;

--- a/groups/nts/ntsa/ntsa_timestamptype.h
+++ b/groups/nts/ntsa/ntsa_timestamptype.h
@@ -25,7 +25,7 @@ BSLS_IDENT("$Id: $")
 namespace BloombergLP {
 namespace ntsa {
 
-/// Provide an enumeration of the timestamp types.
+/// Provide an enumeration of the outgoing timestamp types.
 ///
 /// @par Thread Safety
 /// This struct is thread safe.
@@ -33,11 +33,27 @@ namespace ntsa {
 /// @ingroup module_ntsa_identity
 struct TimestampType {
   public:
-    /// Provide an enumeration of the endpoint types.
+    /// Provide an enumeration of the timestamp types.
     enum Value {
-        e_UNDEFINED    = 0,
+        /// The timestamp type is undefined.
+        e_UNDEFINED = 0,
+
+        /// The timestamp measured at the time when the data enters the 
+        /// packet scheduler. The delta between such a timestamp and the time
+        /// immediately before the data is enqueued to the send buffer is the
+        /// time spent processing the data required by transport protocol.
         e_SCHEDULED    = 1,
-        e_SENT         = 2,
+
+        /// The timestamp measured at the time when the data leaves the
+        /// operating system and is enqueue in the network device for 
+        /// transmission. The delta between such a timestamp and the scheduled
+        /// timestamp is the time spending processing the data independant of
+        /// the transport protocol.
+        e_SENT = 2,
+
+        /// The timestamp measured at the time when the ackowledgement of the
+        /// outgoing data has been received from the peer, for positive 
+        /// acknowledgement transport protocols such as TCP.
         e_ACKNOWLEDGED = 3
     };
 

--- a/groups/nts/ntsa/ntsa_zerocopy.h
+++ b/groups/nts/ntsa/ntsa_zerocopy.h
@@ -21,32 +21,26 @@ BSLS_IDENT("$Id: $")
 
 #include <ntscfg_platform.h>
 #include <ntsscm_version.h>
-
 #include <bslh_hash.h>
 #include <bsl_ostream.h>
 
 namespace BloombergLP {
 namespace ntsa {
 
-/// Provide a type holding a result of send() with copy avoidance mechanis.
-///
-/// @details
-/// Provide a value-semantic type that holds a result of send() with
-/// MSG_ZEROCOPY flag set.
+/// Describe a notification for the completion of one or more send operations
+/// with zero-copy semantics.
 ///
 /// @par Attributes
 /// This class is composed of the following attributes:
 ///
-/// @li @b d_from:
-/// Number identifying the start of the range for which this result relates
-/// (inclusive)
+/// @li @b from:
+/// The identifier of the first zero-copy send that completed, inclusive.
 ///
-/// @li @b d_to:
-/// Number identifying the end of the range for which this result relates
-/// (inclusive)
+/// @li @b to:
+/// The identifier of the last zero-copy send that completed, inclusive.
 ///
-/// @li @b d_code:
-/// Code describing result of copy avoidance mechanism application.
+/// @li @b code:
+/// The code indicating whether the copy was avoided or was performed.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
@@ -57,7 +51,6 @@ class ZeroCopy
     bsl::uint8_t  d_code;
 
   public:
-
     /// Create a new instance having the default value.
     ZeroCopy();
 
@@ -76,28 +69,28 @@ class ZeroCopy
     /// a reference to this modifiable object.
     ZeroCopy& operator=(const ZeroCopy& other);
 
-    /// Set the number identifying the start (inclusive) of the range for which
-    /// this object relates to the specified 'value'.
+    /// Set the identifier of the first zero-copy send that completed, 
+    /// inclusive, to the specified 'value'. 
     void setFrom(bsl::uint32_t value);
 
-    /// Set the number identifying the end (inclusive) of the range for which
-    /// this object relates to the specified 'value'.
+    /// Set the identifier of the last zero-copy send that completed, 
+    /// inclusive, to the specified 'value'. 
     void setTo(bsl::uint32_t value);
 
-    /// Set the code describing result of copy avoidance mechanism application
-    /// to the specified value.
+    /// Set the code indicating whether the copy was avoided or was performed
+    /// to the specified 'value'.
     void setCode(bsl::uint8_t value);
 
-    /// Return the number identifying the start (inclusive) of the range for
-    /// which this object relates.
+    /// Return the identifier of the first zero-copy send that completed, 
+    /// inclusive.
     BSLS_ANNOTATION_NODISCARD bsl::uint32_t from() const;
 
-    /// Return the number identifying the end (inclusive) of the range for
-    /// which this object relates.
+    /// Return the identifier of the last zero-copy send that completed, 
+    /// inclusive.
     BSLS_ANNOTATION_NODISCARD bsl::uint32_t to() const;
 
-    /// Return the code describing result of copy avoidance mechanism
-    /// application.
+    /// Return the code indicating whether the copy was avoided or was 
+    /// performed.
     BSLS_ANNOTATION_NODISCARD bsl::uint8_t code() const;
 
     /// Return true if this object has the same value as the specified
@@ -108,17 +101,16 @@ class ZeroCopy
     /// the specified 'other' object, otherwise return false.
     BSLS_ANNOTATION_NODISCARD bool less(const ZeroCopy& other) const;
 
-    /// Format this object to the specified output 'stream' at the
-    /// optionally specified indentation 'level' and return a reference to
-    /// the modifiable 'stream'.  If 'level' is specified, optionally
-    /// specify 'spacesPerLevel', the number of spaces per indentation level
-    /// for this and all of its nested objects.  Each line is indented by
-    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
-    /// negative, suppress indentation of the first line.  If
-    /// 'spacesPerLevel' is negative, suppress line breaks and format the
-    /// entire output on one line.  If 'stream' is initially invalid, this
-    /// operation has no effect.  Note that a trailing newline is provided
-    /// in multiline mode only.
+    /// Format this object to the specified output 'stream' at the optionally
+    /// specified indentation 'level' and return a reference to the modifiable
+    /// 'stream'.  If 'level' is specified, optionally specify
+    /// 'spacesPerLevel', the number of spaces per indentation level for this
+    /// and all of its nested objects.  Each line is indented by the absolute
+    /// value of 'level * spacesPerLevel'.  If 'level' is negative, suppress
+    /// indentation of the first line.  If 'spacesPerLevel' is negative,
+    /// suppress line breaks and format the entire output on one line.  If
+    /// 'stream' is initially invalid, this operation has no effect.  Note that
+    /// a trailing newline is provided in multiline mode only.
     bsl::ostream& print(bsl::ostream& stream,
                         int           level          = 0,
                         int           spacesPerLevel = 4) const;

--- a/groups/nts/ntsu/ntsu_socketoptionutil.h
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.h
@@ -71,15 +71,6 @@ struct SocketOptionUtil {
     /// according to the specified 'reuseAddress' flag. Return the error.
     static ntsa::Error setReuseAddress(ntsa::Handle socket, bool reuseAddress);
 
-    /// Set the option for the specified 'socket' that enables or disables
-    /// application of both software and hardware timestamps for incoming
-    /// data according to the specified 'timestampIncomingData' flag. Note
-    /// that if an error is returned then timestamps will never be
-    /// generated. If there is no error returned then in some cases OS can
-    /// also refuse to generate timestamps.
-    static ntsa::Error setTimestampIncomingData(ntsa::Handle socket,
-                                                bool timestampIncomingData);
-
     /// Set the option for the specified 'oscket' that controls how the
     /// operating system will linger its underlying resources after it has
     /// been closed to the specified 'linger' flag for the specified
@@ -130,6 +121,15 @@ struct SocketOptionUtil {
                                               bool         inlineFlag);
 
     /// Set the option for the specified 'socket' that enables or disables
+    /// application of both software and hardware timestamps for incoming
+    /// data according to the specified 'timestampIncomingData' flag. Note
+    /// that if an error is returned then timestamps will never be
+    /// generated. If there is no error returned then in some cases OS can
+    /// also refuse to generate timestamps.
+    static ntsa::Error setTimestampIncomingData(ntsa::Handle socket,
+                                                bool timestampIncomingData);
+
+    /// Set the option for the specified 'socket' that enables or disables
     /// application of timestamps for outgoing data according to the specified
     /// 'timestampOutgoingData' flag. Note that if an error is returned then
     /// timestamps will never be generated. If there is no error returned then
@@ -138,10 +138,9 @@ struct SocketOptionUtil {
                                                 bool timestampOutgoingData);
 
     /// Set the option for the specified 'socket' that allows Linux
-    /// MSG_ZEROCOPY mechanism usage according to the specified
-    /// 'allowMsgZeroCopy' flag. Return the error.
-    static ntsa::Error setAllowMsgZeroCopy(ntsa::Handle socket,
-                                           bool         allowMsgZeroCopy);
+    /// MSG_ZEROCOPY mechanism usage according to the specified 'zeroCopy'
+    /// flag. Return the error.
+    static ntsa::Error setZeroCopy(ntsa::Handle socket, bool zeroCopy);
 
     /// Load into the specified 'option' the socket option of the specified
     /// 'type' for the specified 'socket'. Return the error.
@@ -228,8 +227,8 @@ struct SocketOptionUtil {
     /// Load into the specified 'zeroCopyFlag' the option for the specified
     /// 'socket' that indicates if Linux MSG_ZEROCOPY mechanism can be used.
     ///  Return the error.
-    static ntsa::Error getAllowMsgZeroCopy(bool*        zeroCopyFlag,
-                                           ntsa::Handle socket);
+    static ntsa::Error getZeroCopy(bool*        zeroCopyFlag,
+                                   ntsa::Handle socket);
 
     /// Load into the specified 'size' the option for the specified 'socket'
     /// that indicates the amount of space left in the send buffer. Return

--- a/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
@@ -1857,42 +1857,42 @@ NTSCFG_TEST_CASE(9)
         if (setSupported && getSupported) {
             bool zeroCopy = true;
             error =
-                ntsu::SocketOptionUtil::getAllowMsgZeroCopy(&zeroCopy, socket);
+                ntsu::SocketOptionUtil::getZeroCopy(&zeroCopy, socket);
             NTSCFG_TEST_OK(error);
             NTSCFG_TEST_FALSE(zeroCopy);
 
-            error = ntsu::SocketOptionUtil::setAllowMsgZeroCopy(socket, true);
+            error = ntsu::SocketOptionUtil::setZeroCopy(socket, true);
             NTSCFG_TEST_OK(error);
 
             zeroCopy = false;
             error =
-                ntsu::SocketOptionUtil::getAllowMsgZeroCopy(&zeroCopy, socket);
+                ntsu::SocketOptionUtil::getZeroCopy(&zeroCopy, socket);
             NTSCFG_TEST_OK(error);
             NTSCFG_TEST_TRUE(zeroCopy);
 
-            error = ntsu::SocketOptionUtil::setAllowMsgZeroCopy(socket, false);
+            error = ntsu::SocketOptionUtil::setZeroCopy(socket, false);
             NTSCFG_TEST_OK(error);
 
             zeroCopy = true;
             error =
-                ntsu::SocketOptionUtil::getAllowMsgZeroCopy(&zeroCopy, socket);
+                ntsu::SocketOptionUtil::getZeroCopy(&zeroCopy, socket);
             NTSCFG_TEST_OK(error);
             NTSCFG_TEST_FALSE(zeroCopy);
         }
         else if (setSupported == false && getSupported == true) {
             bool zeroCopy = true;
             error =
-                ntsu::SocketOptionUtil::getAllowMsgZeroCopy(&zeroCopy, socket);
+                ntsu::SocketOptionUtil::getZeroCopy(&zeroCopy, socket);
             NTSCFG_TEST_OK(error);
             NTSCFG_TEST_FALSE(zeroCopy);
 
-            error = ntsu::SocketOptionUtil::setAllowMsgZeroCopy(socket, false);
+            error = ntsu::SocketOptionUtil::setZeroCopy(socket, false);
             NTSCFG_TEST_TRUE(error);
         }
         else if (setSupported == false && getSupported == false) {
             bool zeroCopy = true;
             error =
-                ntsu::SocketOptionUtil::getAllowMsgZeroCopy(&zeroCopy, socket);
+                ntsu::SocketOptionUtil::getZeroCopy(&zeroCopy, socket);
             NTSCFG_TEST_ERROR(error,
                               ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED));
             NTSCFG_TEST_TRUE(zeroCopy);

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -2243,8 +2243,14 @@ void testDatagramSocketTxTimestampsAndZeroCopy(
     error = ntsu::SocketOptionUtil::setZeroCopy(client, true);
     NTSCFG_TEST_OK(error);
 
-    const int msgSize           = 200;
-    const int numMessagesToSend = 100;
+    // Note that zero-copy requires significantly more resources on the
+    // receiver's side. Sending a large number of bigger datagram may exceed
+    // the receiver's capacity to receive them, resulting in successful sends
+    // but dropped datagrams, resulting in the receiver blocking indefinitely
+    // receiving datagram from the receive buffer.
+
+    const int msgSize           = 100;
+    const int numMessagesToSend = 10;
 
     bsl::vector<char> message(msgSize, allocator);
     for (int i = 0; i < msgSize; ++i) {

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -1926,7 +1926,7 @@ void testStreamSocketMsgZeroCopy(ntsa::Transport::Value transport,
 
     ntsa::Error error;
 
-    error = ntsu::SocketOptionUtil::setAllowMsgZeroCopy(client, true);
+    error = ntsu::SocketOptionUtil::setZeroCopy(client, true);
     NTSCFG_TEST_OK(error);
 
     bsl::vector<char> message(msgSize, allocator);
@@ -2240,7 +2240,7 @@ void testDatagramSocketTxTimestampsAndZeroCopy(
     error = ntsu::SocketOptionUtil::setTimestampOutgoingData(client, true);
     NTSCFG_TEST_OK(error);
 
-    error = ntsu::SocketOptionUtil::setAllowMsgZeroCopy(client, true);
+    error = ntsu::SocketOptionUtil::setZeroCopy(client, true);
     NTSCFG_TEST_OK(error);
 
     const int msgSize           = 200;
@@ -2371,7 +2371,7 @@ void testStreamSocketTxTimestampsAndZeroCopy(ntsa::Transport::Value transport,
     error = ntsu::SocketOptionUtil::setTimestampOutgoingData(client, true);
     NTSCFG_TEST_OK(error);
 
-    error = ntsu::SocketOptionUtil::setAllowMsgZeroCopy(client, true);
+    error = ntsu::SocketOptionUtil::setZeroCopy(client, true);
     NTSCFG_TEST_OK(error);
 
     const int msgSize           = 200;
@@ -7775,7 +7775,7 @@ NTSCFG_TEST_CASE(27)
             error = ntsu::SocketUtil::create(&handle, *transport);
             NTSCFG_TEST_ASSERT(!error);
 
-            error = ntsu::SocketOptionUtil::setAllowMsgZeroCopy(handle, true);
+            error = ntsu::SocketOptionUtil::setZeroCopy(handle, true);
             NTSCFG_TEST_OK(error);
 
             bsl::vector<char> message(msgSize, &ta);

--- a/groups/nts/ntsu/ntsu_timestamputil.cpp
+++ b/groups/nts/ntsu/ntsu_timestamputil.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ntsu_timestamputil.h"
+#include <ntsu_timestamputil.h>
 
 #include <bslmf_assert.h>
 #include <bsls_platform.h>

--- a/groups/nts/ntsu/ntsu_zerocopyutil.cpp
+++ b/groups/nts/ntsu/ntsu_zerocopyutil.cpp
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "ntsu_msgzerocopyutil.h"
+#include <ntsu_zerocopyutil.h>
 
 #include <bslmf_assert.h>
 #include <bsls_platform.h>
@@ -34,14 +34,14 @@ namespace ntsu {
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
 
-BSLMF_ASSERT(MsgzerocopyUtil::e_SO_ZEROCOPY == static_cast<int>(SO_ZEROCOPY));
+BSLMF_ASSERT(ZeroCopyUtil::e_SO_ZEROCOPY == static_cast<int>(SO_ZEROCOPY));
 
-BSLMF_ASSERT(MsgzerocopyUtil::e_MSG_ZEROCOPY ==
+BSLMF_ASSERT(ZeroCopyUtil::e_MSG_ZEROCOPY ==
              static_cast<int>(MSG_ZEROCOPY));
 
-BSLMF_ASSERT(MsgzerocopyUtil::e_SO_EE_ORIGIN_ZEROCOPY ==
+BSLMF_ASSERT(ZeroCopyUtil::e_SO_EE_ORIGIN_ZEROCOPY ==
              static_cast<int>(SO_EE_ORIGIN_ZEROCOPY));
-BSLMF_ASSERT(MsgzerocopyUtil::e_SO_EE_CODE_ZEROCOPY_COPIED ==
+BSLMF_ASSERT(ZeroCopyUtil::e_SO_EE_CODE_ZEROCOPY_COPIED ==
              static_cast<int>(SO_EE_CODE_ZEROCOPY_COPIED));
 
 #endif

--- a/groups/nts/ntsu/ntsu_zerocopyutil.h
+++ b/groups/nts/ntsu/ntsu_zerocopyutil.h
@@ -13,8 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef INCLUDED_NTSU_MSGZEROCOPYUTIL
-#define INCLUDED_NTSU_MSGZEROCOPYUTIL
+#ifndef INCLUDED_NTSU_ZEROCOPYUTIL
+#define INCLUDED_NTSU_ZEROCOPYUTIL
 
 #include <bsls_ident.h>
 BSLS_IDENT("$Id: $")
@@ -24,8 +24,7 @@ namespace ntsu {
 
 /// This struct is used to define/redefine types and constants used for Linux
 /// msg zerocopy feature.
-
-struct MsgzerocopyUtil {
+struct ZeroCopyUtil {
     enum {  //copied from include/asm-generic/socket.h
         e_SO_ZEROCOPY = 60
     };

--- a/targets.cmake
+++ b/targets.cmake
@@ -214,7 +214,7 @@ if (${NTF_BUILD_WITH_NTS})
 
     ntf_component(NAME ntsu_adapterutil)
     ntf_component(NAME ntsu_bufferutil)
-    ntf_component(NAME ntsu_msgzerocopyutil)
+    ntf_component(NAME ntsu_zerocopyutil)
     ntf_component(NAME ntsu_resolverutil)
     ntf_component(NAME ntsu_socketutil)
     ntf_component(NAME ntsu_socketoptionutil)


### PR DESCRIPTION
This PR revises and expands the documentation written pertaining to the zero-copy and the previous timestamping features, makes some cosmetic changes regarding file, type, and function names, and fixes some small parts of the socket option implementation that were missing on the main branch.

One desired change that was not made is to enhance ntsa::ZeroCopy::d_code into some sort of enumeration. That change was not made but is probably a good idea.