### PR TITLE
Revise strategy to support zero-copy on Linux and handle out-of-order zero-copy completion intervals

### DIFF
--- a/groups/ntc/ntca/ntca_datagramsocketoptions.cpp
+++ b/groups/ntc/ntca/ntca_datagramsocketoptions.cpp
@@ -501,12 +501,6 @@ const bdlb::NullableValue<bsl::size_t>& DatagramSocketOptions::
     return d_zeroCopyThreshold;
 }
 
-bdlb::NullableValue<bsl::size_t>& DatagramSocketOptions::
-    zeroCopyThreshold()
-{
-    return d_zeroCopyThreshold;
-}
-
 bsl::ostream& DatagramSocketOptions::print(bsl::ostream& stream,
                                            int           level,
                                            int           spacesPerLevel) const

--- a/groups/ntc/ntca/ntca_datagramsocketoptions.h
+++ b/groups/ntc/ntca/ntca_datagramsocketoptions.h
@@ -183,6 +183,10 @@ namespace ntca {
 /// @li @b timestampIncomingData:
 /// The flag that indicates incoming data should be timestamped.
 ///
+/// @li @b zeroCopyThreshold:
+/// The minimum number of bytes that must be available to send in order to
+/// attempt a zero-copy send.
+///
 /// @li @b loadBalancingOptions:
 /// The configurable parameters used select a reactor or proactor that drives
 /// the I/O for the socket.
@@ -342,12 +346,16 @@ class DatagramSocketOptions
     /// the specified 'value'.
     void setMetrics(bool value);
 
-    /// Set the flag that indicates outgoing data should be timestamped.
+    /// Set the flag that indicates outgoing data should be timestamped to the
+    /// specified 'value'.
     void setTimestampOutgoingData(bool value);
 
-    /// Return the flag that indicates incoming data should be timestamped.
+    /// Set the flag that indicates incoming data should be timestamped to the
+    /// specified 'value'.
     void setTimestampIncomingData(bool value);
 
+    /// Set the minimum number of bytes that must be available to send in order
+    /// to attempt a zero-copy send to the specified 'value'.
     void setZeroCopyThreshold(bsl::size_t value);
 
     /// Set the load balancing options to the specified 'value'.
@@ -454,8 +462,9 @@ class DatagramSocketOptions
     /// Return the flag that indicates incoming data should be timestamped.
     const bdlb::NullableValue<bool>& timestampIncomingData() const;
 
+    /// Return the minimum number of bytes that must be available to send in
+    /// order to attempt a zero-copy send.
     const bdlb::NullableValue<bsl::size_t>& zeroCopyThreshold() const;
-    bdlb::NullableValue<bsl::size_t>& zeroCopyThreshold();
 
     /// Return the load balancing options.
     const ntca::LoadBalancingOptions& loadBalancingOptions() const;

--- a/groups/ntc/ntca/ntca_interfaceconfig.cpp
+++ b/groups/ntc/ntca/ntca_interfaceconfig.cpp
@@ -19,6 +19,7 @@
 BSLS_IDENT_RCSID(ntca_interfaceconfig_cpp, "$Id$ $CSID$")
 
 #include <ntccfg_limits.h>
+#include <bslim_printer.h>
 
 namespace BloombergLP {
 namespace ntca {
@@ -53,6 +54,9 @@ InterfaceConfig::InterfaceConfig(bslma::Allocator* basicAllocator)
 , d_receiveBufferLowWatermark()
 , d_sendTimeout()
 , d_receiveTimeout()
+, d_timestampOutgoingData()
+, d_timestampIncomingData()
+, d_zeroCopyThreshold()
 , d_keepAlive()
 , d_noDelay()
 , d_debugFlag()
@@ -107,6 +111,9 @@ InterfaceConfig::InterfaceConfig(const InterfaceConfig& other,
 , d_receiveBufferLowWatermark(other.d_receiveBufferLowWatermark)
 , d_sendTimeout(other.d_sendTimeout)
 , d_receiveTimeout(other.d_receiveTimeout)
+, d_timestampOutgoingData(other.d_timestampOutgoingData)
+, d_timestampIncomingData(other.d_timestampIncomingData)
+, d_zeroCopyThreshold(other.d_zeroCopyThreshold)
 , d_keepAlive(other.d_keepAlive)
 , d_noDelay(other.d_noDelay)
 , d_debugFlag(other.d_debugFlag)
@@ -168,6 +175,9 @@ InterfaceConfig& InterfaceConfig::operator=(const InterfaceConfig& other)
         d_receiveBufferLowWatermark = other.d_receiveBufferLowWatermark;
         d_sendTimeout               = other.d_sendTimeout;
         d_receiveTimeout            = other.d_receiveTimeout;
+        d_timestampOutgoingData     = other.d_timestampOutgoingData;
+        d_timestampIncomingData     = other.d_timestampIncomingData;
+        d_zeroCopyThreshold         = other.d_zeroCopyThreshold;
         d_keepAlive                 = other.d_keepAlive;
         d_noDelay                   = other.d_noDelay;
         d_debugFlag                 = other.d_debugFlag;
@@ -336,6 +346,21 @@ void InterfaceConfig::setSendTimeout(bsl::size_t value)
 void InterfaceConfig::setReceiveTimeout(bsl::size_t value)
 {
     d_receiveTimeout = value;
+}
+
+void InterfaceConfig::setTimestampOutgoingData(bool value)
+{
+    d_timestampOutgoingData = value;
+}
+
+void InterfaceConfig::setTimestampIncomingData(bool value)
+{
+    d_timestampIncomingData = value;
+}
+
+void InterfaceConfig::setZeroCopyThreshold(size_t value)
+{
+    d_zeroCopyThreshold = value;
 }
 
 void InterfaceConfig::setKeepAlive(bool value)
@@ -597,6 +622,24 @@ const bdlb::NullableValue<bsl::size_t>& InterfaceConfig::receiveTimeout() const
     return d_receiveTimeout;
 }
 
+const bdlb::NullableValue<bool>& InterfaceConfig::timestampOutgoingData()
+    const
+{
+    return d_timestampOutgoingData;
+}
+
+const bdlb::NullableValue<bool>& InterfaceConfig::timestampIncomingData()
+    const
+{
+    return d_timestampIncomingData;
+}
+
+const bdlb::NullableValue<bsl::size_t>& 
+InterfaceConfig::zeroCopyThreshold() const
+{
+    return d_zeroCopyThreshold;
+}
+
 const bdlb::NullableValue<bool>& InterfaceConfig::keepAlive() const
 {
     return d_keepAlive;
@@ -702,6 +745,238 @@ const bdlb::NullableValue<ntca::ResolverConfig>& InterfaceConfig::
     resolverConfig() const
 {
     return d_resolverConfig;
+}
+
+bsl::ostream& InterfaceConfig::print(bsl::ostream& stream,
+                                     int           level,
+                                     int           spacesPerLevel) const
+{
+    bslim::Printer printer(&stream, level, spacesPerLevel);
+    printer.start();
+
+    if (!d_driverName.empty()) {
+        printer.printAttribute("driverName", d_driverName);
+    }
+
+    if (!d_metricName.empty()) {
+        printer.printAttribute("metricName", d_metricName);
+    }
+
+    if (!d_threadName.empty()) {
+        printer.printAttribute("threadName", d_threadName);
+    }
+
+    printer.printAttribute("minThreads", d_minThreads);
+    printer.printAttribute("maxThreads", d_maxThreads);
+    printer.printAttribute("threadStackSize", d_threadStackSize);
+    printer.printAttribute("threadLoadFactor", d_threadLoadFactor);
+
+    if (!d_maxEventsPerWait.isNull()) {
+        printer.printAttribute("maxEventsPerWait", d_maxEventsPerWait);
+    }
+
+    if (!d_maxTimersPerWait.isNull()) {
+        printer.printAttribute("maxTimersPerWait", d_maxTimersPerWait);
+    }
+
+    if (!d_maxCyclesPerWait.isNull()) {
+        printer.printAttribute("maxCyclesPerWait", d_maxCyclesPerWait);
+    }
+
+    if (!d_maxConnections.isNull()) {
+        printer.printAttribute("maxConnections", d_maxConnections);
+    }
+
+    if (!d_backlog.isNull()) {
+        printer.printAttribute("backlog", d_backlog);
+    }
+
+    if (!d_acceptQueueLowWatermark.isNull()) {
+        printer.printAttribute(
+            "acceptQueueLowWatermark", d_acceptQueueLowWatermark);
+    }
+
+    if (!d_acceptQueueHighWatermark.isNull()) {
+        printer.printAttribute(
+            "acceptQueueHighWatermark", d_acceptQueueHighWatermark);
+    }
+
+    if (!d_readQueueLowWatermark.isNull()) {
+        printer.printAttribute(
+            "readQueueLowWatermark", d_readQueueLowWatermark);
+    }
+
+    if (!d_readQueueHighWatermark.isNull()) {
+        printer.printAttribute(
+            "readQueueHighWatermark", d_readQueueHighWatermark);
+    }
+
+    if (!d_writeQueueLowWatermark.isNull()) {
+        printer.printAttribute(
+            "writeQueueLowWatermark", d_writeQueueLowWatermark);
+    }
+
+    if (!d_writeQueueHighWatermark.isNull()) {
+        printer.printAttribute(
+            "writeQueueHighWatermark", d_writeQueueHighWatermark);
+    }
+
+    if (!d_minIncomingStreamTransferSize.isNull()) {
+        printer.printAttribute(
+            "minIncomingStreamTransferSize", 
+            d_minIncomingStreamTransferSize);
+    }
+
+    if (!d_maxIncomingStreamTransferSize.isNull()) {
+        printer.printAttribute(
+            "maxIncomingStreamTransferSize", 
+            d_maxIncomingStreamTransferSize);
+    }
+
+    if (!d_acceptGreedily.isNull()) {
+        printer.printAttribute("acceptGreedily", d_acceptGreedily);
+    }
+
+    if (!d_sendGreedily.isNull()) {
+        printer.printAttribute("sendGreedily", d_sendGreedily);
+    }
+
+    if (!d_receiveGreedily.isNull()) {
+        printer.printAttribute("receiveGreedily", d_receiveGreedily);
+    }
+
+    if (!d_sendBufferSize.isNull()) {
+        printer.printAttribute("sendBufferSize", d_sendBufferSize);
+    }
+
+    if (!d_receiveBufferSize.isNull()) {
+        printer.printAttribute("receiveBufferSize", d_receiveBufferSize);
+    }
+
+    if (!d_sendBufferLowWatermark.isNull()) {
+        printer.printAttribute(
+            "sendBufferLowWatermark", d_sendBufferLowWatermark);
+    }
+
+    if (!d_receiveBufferLowWatermark.isNull()) {
+        printer.printAttribute(
+            "receiveBufferLowWatermark", d_receiveBufferLowWatermark);
+    }
+
+    if (!d_sendTimeout.isNull()) {
+        printer.printAttribute("sendTimeout", d_sendTimeout);
+    }
+
+    if (!d_receiveTimeout.isNull()) {
+        printer.printAttribute("receiveTimeout", d_receiveTimeout);
+    }
+
+    if (!d_timestampOutgoingData.isNull()) {
+        printer.printAttribute(
+            "timestampOutgoingData", d_timestampOutgoingData);
+    }
+
+    if (!d_timestampIncomingData.isNull()) {
+        printer.printAttribute(
+            "timestampIncomingData", d_timestampIncomingData);
+    }
+
+    if (!d_zeroCopyThreshold.isNull()) {
+        printer.printAttribute(
+            "zeroCopyThreshold", d_zeroCopyThreshold);
+    }
+
+    if (!d_keepAlive.isNull()) {
+        printer.printAttribute("keepAlive", d_keepAlive);
+    }
+
+    if (!d_noDelay.isNull()) {
+        printer.printAttribute("noDelay", d_noDelay);
+    }
+
+    if (!d_debugFlag.isNull()) {
+        printer.printAttribute("debugFlag", d_debugFlag);
+    }
+
+    if (!d_allowBroadcasting.isNull()) {
+        printer.printAttribute("allowBroadcasting", d_allowBroadcasting);
+    }
+
+    if (!d_bypassNormalRouting.isNull()) {
+        printer.printAttribute("bypassNormalRouting", d_bypassNormalRouting);
+    }
+
+    if (!d_leaveOutOfBandDataInline.isNull()) {
+        printer.printAttribute(
+            "leaveOutOfBandDataInline", d_leaveOutOfBandDataInline);
+    }
+
+    if (!d_lingerFlag.isNull()) {
+        printer.printAttribute("lingerFlag", d_lingerFlag);
+    }
+
+    if (!d_lingerTimeout.isNull()) {
+        printer.printAttribute("lingerTimeout", d_lingerTimeout);
+    }
+
+    if (!d_keepHalfOpen.isNull()) {
+        printer.printAttribute("keepHalfOpen", d_keepHalfOpen);
+    }
+
+    if (!d_maxDatagramSize.isNull()) {
+        printer.printAttribute("maxDatagramSize", d_maxDatagramSize);
+    }
+
+    if (!d_multicastLoopback.isNull()) {
+        printer.printAttribute("multicastLoopback", d_multicastLoopback);
+    }
+
+    if (!d_multicastTimeToLive.isNull()) {
+        printer.printAttribute("multicastTimeToLive", d_multicastTimeToLive);
+    }
+
+    if (!d_multicastInterface.isNull()) {
+        printer.printAttribute("multicastInterface", d_multicastInterface);
+    }
+
+    if (!d_dynamicLoadBalancing.isNull()) {
+        printer.printAttribute("dynamicLoadBalancing", d_dynamicLoadBalancing);
+    }
+
+    if (!d_driverMetrics.isNull()) {
+        printer.printAttribute("driverMetrics", d_driverMetrics);
+    }
+
+    if (!d_driverMetricsPerWaiter.isNull()) {
+        printer.printAttribute(
+            "driverMetricsPerWaiter", d_driverMetricsPerWaiter);
+    }
+
+    if (!d_socketMetrics.isNull()) {
+        printer.printAttribute("socketMetrics", d_socketMetrics);
+    }
+
+    if (!d_socketMetricsPerHandle.isNull()) {
+        printer.printAttribute(
+            "socketMetricsPerHandle", d_socketMetricsPerHandle);
+    }
+
+    if (!d_resolverEnabled.isNull()) {
+        printer.printAttribute("resolverEnabled", d_resolverEnabled);
+    }
+
+    if (!d_resolverConfig.isNull()) {
+        printer.printAttribute("resolverConfig", d_resolverConfig);
+    }
+
+    printer.end();
+    return stream;
+}
+
+bsl::ostream& operator<<(bsl::ostream&          stream,
+                         const InterfaceConfig& object)
+{
+    return object.print(stream, 0, -1);
 }
 
 }  // close package namespace

--- a/groups/ntc/ntca/ntca_interfaceconfig.h
+++ b/groups/ntc/ntca/ntca_interfaceconfig.h
@@ -196,6 +196,16 @@ namespace ntca {
 /// deemed to have failed. This option is not widely supported and should be
 /// avoided.
 ///
+/// @li @b timestampOutgoingData:
+/// The flag that indicates outgoing data should be timestamped.
+///
+/// @li @b timestampIncomingData:
+/// The flag that indicates incoming data should be timestamped.
+///
+/// @li @b zeroCopyThreshold:
+/// The minimum number of bytes that must be available to send in order to
+/// attempt a zero-copy send.
+///
 /// @li @b keepAlive:
 /// That flag that indicates the operating system implementation should
 /// periodically emit transport-level "keep-alive" packets.
@@ -327,6 +337,11 @@ class InterfaceConfig
     bdlb::NullableValue<bsl::size_t> d_receiveBufferLowWatermark;
     bdlb::NullableValue<bsl::size_t> d_sendTimeout;
     bdlb::NullableValue<bsl::size_t> d_receiveTimeout;
+
+    bdlb::NullableValue<bool>           d_timestampOutgoingData;
+    bdlb::NullableValue<bool>           d_timestampIncomingData;
+    bdlb::NullableValue<bsl::size_t>    d_zeroCopyThreshold;
+
     bdlb::NullableValue<bool>        d_keepAlive;
     bdlb::NullableValue<bool>        d_noDelay;
     bdlb::NullableValue<bool>        d_debugFlag;
@@ -472,6 +487,18 @@ class InterfaceConfig
 
     /// Set the receive timeout to the specified 'value'.
     void setReceiveTimeout(bsl::size_t value);
+
+    /// Set the flag that indicates outgoing data should be timestamped to the
+    /// specified 'value'.
+    void setTimestampOutgoingData(bool value);
+
+    /// Set the flag that indicates incoming data should be timestamped to the
+    /// specified 'value'.
+    void setTimestampIncomingData(bool value);
+
+    /// Set the minimum number of bytes that must be available to send in order
+    /// to attempt a zero-copy send to the specified 'value'.
+    void setZeroCopyThreshold(size_t value);
 
     /// Set the flag enable protocol-level keep-alive messages to the
     /// specified 'value'.
@@ -654,6 +681,16 @@ class InterfaceConfig
     /// Return the receive timeout.
     const bdlb::NullableValue<bsl::size_t>& receiveTimeout() const;
 
+    /// Return the flag that indicates outgoing data should be timestamped.
+    const bdlb::NullableValue<bool>& timestampOutgoingData() const;
+
+    /// Return the flag that indicates incoming data should be timestamped.
+    const bdlb::NullableValue<bool>& timestampIncomingData() const;
+
+    /// Return the minimum number of bytes that must be available to send in
+    /// order to attempt a zero-copy send.
+    const bdlb::NullableValue<bsl::size_t>& zeroCopyThreshold() const;
+
     /// Return the flag enable protocol-level keep-alive messages.
     const bdlb::NullableValue<bool>& keepAlive() const;
 
@@ -728,7 +765,29 @@ class InterfaceConfig
     /// null, indicating that when an asynchronous resolver is enabled it is
     /// configured with the default configuration.
     const bdlb::NullableValue<ntca::ResolverConfig>& resolverConfig() const;
+
+    /// Format this object to the specified output 'stream' at the
+    /// optionally specified indentation 'level' and return a reference to
+    /// the modifiable 'stream'.  If 'level' is specified, optionally
+    /// specify 'spacesPerLevel', the number of spaces per indentation level
+    /// for this and all of its nested objects.  Each line is indented by
+    /// the absolute value of 'level * spacesPerLevel'.  If 'level' is
+    /// negative, suppress indentation of the first line.  If
+    /// 'spacesPerLevel' is negative, suppress line breaks and format the
+    /// entire output on one line.  If 'stream' is initially invalid, this
+    /// operation has no effect.  Note that a trailing newline is provided
+    /// in multiline mode only.
+    bsl::ostream& print(bsl::ostream& stream,
+                        int           level          = 0,
+                        int           spacesPerLevel = 4) const;
 };
+
+/// Format the specified 'object' to the specified output 'stream' and
+/// return a reference to the modifiable 'stream'.
+///
+/// @related ntca::InterfaceConfig
+bsl::ostream& operator<<(bsl::ostream&          stream,
+                         const InterfaceConfig& object);
 
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntca/ntca_listenersocketoptions.cpp
+++ b/groups/ntc/ntca/ntca_listenersocketoptions.cpp
@@ -511,12 +511,6 @@ const bdlb::NullableValue<bool>& ListenerSocketOptions::metrics() const
     return d_metrics;
 }
 
-const ntca::LoadBalancingOptions& ListenerSocketOptions::loadBalancingOptions()
-    const
-{
-    return d_loadBalancingOptions;
-}
-
 const bdlb::NullableValue<bool>& ListenerSocketOptions::timestampOutgoingData()
     const
 {
@@ -533,6 +527,12 @@ const bdlb::NullableValue<bsl::size_t>& ListenerSocketOptions::
     zeroCopyThreshold() const
 {
     return d_zeroCopyThreshold;
+}
+
+const ntca::LoadBalancingOptions& ListenerSocketOptions::loadBalancingOptions()
+    const
+{
+    return d_loadBalancingOptions;
 }
 
 bsl::ostream& ListenerSocketOptions::print(bsl::ostream& stream,

--- a/groups/ntc/ntca/ntca_listenersocketoptions.h
+++ b/groups/ntc/ntca/ntca_listenersocketoptions.h
@@ -199,6 +199,10 @@ namespace ntca {
 /// @li @b timestampIncomingData:
 /// The flag that indicates incoming data should be timestamped.
 ///
+/// @li @b zeroCopyThreshold:
+/// The minimum number of bytes that must be available to send in order to
+/// attempt a zero-copy send.
+///
 /// @li @b loadBalancingOptions:
 /// The configurable parameters used select a reactor or proactor that drives
 /// the I/O for the socket.
@@ -366,16 +370,20 @@ class ListenerSocketOptions
     /// the specified 'value'.
     void setMetrics(bool value);
 
-    /// Set the flag that indicates outgoing data should be timestamped.
+    /// Set the flag that indicates outgoing data should be timestamped to the
+    /// specified 'value'.
     void setTimestampOutgoingData(bool value);
 
-    /// Return the flag that indicates incoming data should be timestamped.
+    /// Set the flag that indicates incoming data should be timestamped to the
+    /// specified 'value'.
     void setTimestampIncomingData(bool value);
+
+    /// Set the minimum number of bytes that must be available to send in order
+    /// to attempt a zero-copy send to the specified 'value'.
+    void setZeroCopyThreshold(size_t value);
 
     /// Set the load balancing options to the specified 'value'.
     void setLoadBalancingOptions(const ntca::LoadBalancingOptions& value);
-
-    void setZeroCopyThreshold(bsl::size_t value);
 
     /// Return the transport.
     ntsa::Transport::Value transport() const;
@@ -485,6 +493,8 @@ class ListenerSocketOptions
     /// Return the flag that indicates incoming data should be timestamped.
     const bdlb::NullableValue<bool>& timestampIncomingData() const;
 
+    /// Return the minimum number of bytes that must be available to send in
+    /// order to attempt a zero-copy send.
     const bdlb::NullableValue<bsl::size_t>& zeroCopyThreshold() const;
 
     /// Return the load balancing options.

--- a/groups/ntc/ntca/ntca_streamsocketoptions.h
+++ b/groups/ntc/ntca/ntca_streamsocketoptions.h
@@ -181,6 +181,10 @@ namespace ntca {
 /// @li @b timestampIncomingData:
 /// The flag that indicates incoming data should be timestamped.
 ///
+/// @li @b zeroCopyThreshold:
+/// The minimum number of bytes that must be available to send in order to
+/// attempt a zero-copy send.
+///
 /// @li @b loadBalancingOptions:
 /// The configurable parameters used select a
 ///   reactor or proactor that drives the I/O for the socket.
@@ -331,12 +335,16 @@ class StreamSocketOptions
     /// the specified 'value'.
     void setMetrics(bool value);
 
-    /// Set the flag that indicates outgoing data should be timestamped.
+    /// Set the flag that indicates outgoing data should be timestamped to the
+    /// specified 'value'.
     void setTimestampOutgoingData(bool value);
 
-    /// Return the flag that indicates incoming data should be timestamped.
+    /// Set the flag that indicates incoming data should be timestamped to the
+    /// specified 'value'.
     void setTimestampIncomingData(bool value);
 
+    /// Set the minimum number of bytes that must be available to send in order
+    /// to attempt a zero-copy send to the specified 'value'.
     void setZeroCopyThreshold(size_t value);
 
     /// Set the load balancing options to the specified 'value'.
@@ -438,6 +446,8 @@ class StreamSocketOptions
     /// Return the flag that indicates incoming data should be timestamped.
     const bdlb::NullableValue<bool>& timestampIncomingData() const;
 
+    /// Return the minimum number of bytes that must be available to send in
+    /// order to attempt a zero-copy send.
     const bdlb::NullableValue<bsl::size_t>& zeroCopyThreshold() const;
 
     /// Return the load balancing options.

--- a/groups/ntc/ntccfg/ntccfg_limits.h
+++ b/groups/ntc/ntccfg/ntccfg_limits.h
@@ -158,12 +158,18 @@ namespace ntccfg {
 /// @ingroup module_ntccfg
 #define NTCCFG_DEFAULT_DATAGRAM_SOCKET_KEEP_HALF_OPEN false
 
-// The maximum size of a datagram socket message, unless specified by the user.
-// In the absense of other information, assume the UDP protocol. The default
-// value is 65507, which is 64K - the size of the UDP header.
+/// The maximum size of a datagram socket message, unless specified by the user.
+/// In the absense of other information, assume the UDP protocol. The default
+/// value is 65507, which is 64K - the size of the UDP header.
 ///
 /// @ingroup module_ntccfg
 #define NTCCFG_DEFAULT_DATAGRAM_SOCKET_MAX_MESSAGE_SIZE 65507
+
+/// The default recommended threshold of data at which to begin to attempt
+/// zero-copy transmission.
+///
+/// @ingroup module_ntccfg
+#define NTCCFG_DEFAULT_ZERO_COPY_THRESHOLD 10240
 
 #if NTC_BUILD_WITH_DYNAMIC_LOAD_BALANCING
 /// The default maximum number of threads supported by this library. The

--- a/groups/ntc/ntci/ntci_datagramsocket.cpp
+++ b/groups/ntc/ntci/ntci_datagramsocket.cpp
@@ -31,7 +31,7 @@ ntsa::Error DatagramSocket::setZeroCopyThreshold(bsl::size_t value)
 {
     NTCCFG_WARNING_UNUSED(value);
 
-    return ntsa::Error();
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
 ntsa::Error DatagramSocket::timestampOutgoingData(bool enable)

--- a/groups/ntc/ntci/ntci_datagramsocket.cpp
+++ b/groups/ntc/ntci/ntci_datagramsocket.cpp
@@ -27,7 +27,21 @@ DatagramSocket::~DatagramSocket()
 {
 }
 
+ntsa::Error DatagramSocket::setZeroCopyThreshold(bsl::size_t value)
+{
+    NTCCFG_WARNING_UNUSED(value);
+
+    return ntsa::Error();
+}
+
 ntsa::Error DatagramSocket::timestampOutgoingData(bool enable)
+{
+    NTCCFG_WARNING_UNUSED(enable);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error DatagramSocket::timestampIncomingData(bool enable)
 {
     NTCCFG_WARNING_UNUSED(enable);
 

--- a/groups/ntc/ntci/ntci_datagramsocket.cpp
+++ b/groups/ntc/ntci/ntci_datagramsocket.cpp
@@ -27,6 +27,13 @@ DatagramSocket::~DatagramSocket()
 {
 }
 
+ntsa::Error DatagramSocket::timestampOutgoingData(bool enable)
+{
+    NTCCFG_WARNING_UNUSED(enable);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 void DatagramSocketCloseGuard::complete(bslmt::Semaphore* semaphore)
 {
     semaphore->post();

--- a/groups/ntc/ntci/ntci_datagramsocket.h
+++ b/groups/ntc/ntci/ntci_datagramsocket.h
@@ -782,6 +782,10 @@ class DatagramSocket : public ntsi::Descriptor,
     /// Return the error.
     virtual ntsa::Error deregisterSession() = 0;
 
+    /// Set the minimum number of bytes that must be available to send in order
+    /// to attempt a zero-copy send to the specified 'value'. Return the error.
+    virtual ntsa::Error setZeroCopyThreshold(bsl::size_t value);
+
     /// Set the write rate limiter to the specified 'rateLimiter'. Return
     /// the error.
     virtual ntsa::Error setWriteRateLimiter(
@@ -850,6 +854,11 @@ class DatagramSocket : public ntsi::Descriptor,
     /// specified 'enable' flag is true. Otherwise, request the implementation
     /// to stop timestamping outgoing data. Return the error.
     virtual ntsa::Error timestampOutgoingData(bool enable);
+
+    /// Request the implementation to start timestamping incoming data if the
+    /// specified 'enable' flag is true. Otherwise, request the implementation
+    /// to stop timestamping outgoing data. Return the error.
+    virtual ntsa::Error timestampIncomingData(bool enable);
 
     /// Enable copying from the socket buffers in the specified 'direction'.
     virtual ntsa::Error relaxFlowControl(

--- a/groups/ntc/ntci/ntci_datagramsocket.h
+++ b/groups/ntc/ntci/ntci_datagramsocket.h
@@ -846,6 +846,11 @@ class DatagramSocket : public ntsi::Descriptor,
     virtual ntsa::Error leaveMulticastGroup(const ntsa::IpAddress& interface,
                                             const ntsa::IpAddress& group) = 0;
 
+    /// Request the implementation to start timestamping outgoing data if the
+    /// specified 'enable' flag is true. Otherwise, request the implementation
+    /// to stop timestamping outgoing data. Return the error.
+    virtual ntsa::Error timestampOutgoingData(bool enable);
+
     /// Enable copying from the socket buffers in the specified 'direction'.
     virtual ntsa::Error relaxFlowControl(
         ntca::FlowControlType::Value direction) = 0;

--- a/groups/ntc/ntci/ntci_sender.cpp
+++ b/groups/ntc/ntci/ntci_sender.cpp
@@ -25,12 +25,5 @@ Sender::~Sender()
 {
 }
 
-ntsa::Error Sender::timestampOutgoingData(bool enable)
-{
-    NTCCFG_WARNING_UNUSED(enable);
-
-    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
-}
-
 }  // close package namespace
 }  // close enterprise namespace

--- a/groups/ntc/ntci/ntci_sender.h
+++ b/groups/ntc/ntci/ntci_sender.h
@@ -276,13 +276,6 @@ class Sender : public ntci::SendCallbackFactory
     /// Return the error.
     virtual ntsa::Error cancel(const ntca::SendToken& token) = 0;
 
-    /// Request the implementation to start timestamping outgoing data if the
-    /// specified 'enable' flag is true. Otherwise, request the implementation
-    /// to stop timestamping outgoing data. Return true if operation was
-    /// successful (though it does not guarantee that transmit timestamps would
-    /// be generated). Otherwise return false.
-    virtual ntsa::Error timestampOutgoingData(bool enable);
-
     /// Return the strand that guarantees sequential, non-current execution
     /// of arbitrary functors on the unspecified threads processing events
     /// for this object.

--- a/groups/ntc/ntci/ntci_streamsocket.cpp
+++ b/groups/ntc/ntci/ntci_streamsocket.cpp
@@ -31,7 +31,7 @@ ntsa::Error StreamSocket::setZeroCopyThreshold(bsl::size_t value)
 {
     NTCCFG_WARNING_UNUSED(value);
 
-    return ntsa::Error();
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
 }
 
 ntsa::Error StreamSocket::timestampOutgoingData(bool enable)

--- a/groups/ntc/ntci/ntci_streamsocket.cpp
+++ b/groups/ntc/ntci/ntci_streamsocket.cpp
@@ -27,6 +27,13 @@ StreamSocket::~StreamSocket()
 {
 }
 
+ntsa::Error StreamSocket::timestampOutgoingData(bool enable)
+{
+    NTCCFG_WARNING_UNUSED(enable);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
 void StreamSocketCloseGuard::complete(bslmt::Semaphore* semaphore)
 {
     semaphore->post();

--- a/groups/ntc/ntci/ntci_streamsocket.cpp
+++ b/groups/ntc/ntci/ntci_streamsocket.cpp
@@ -27,7 +27,21 @@ StreamSocket::~StreamSocket()
 {
 }
 
+ntsa::Error StreamSocket::setZeroCopyThreshold(bsl::size_t value)
+{
+    NTCCFG_WARNING_UNUSED(value);
+
+    return ntsa::Error();
+}
+
 ntsa::Error StreamSocket::timestampOutgoingData(bool enable)
+{
+    NTCCFG_WARNING_UNUSED(enable);
+
+    return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+}
+
+ntsa::Error StreamSocket::timestampIncomingData(bool enable)
 {
     NTCCFG_WARNING_UNUSED(enable);
 

--- a/groups/ntc/ntci/ntci_streamsocket.h
+++ b/groups/ntc/ntci/ntci_streamsocket.h
@@ -1502,6 +1502,11 @@ class StreamSocket : public ntsi::Descriptor,
     virtual ntsa::Error setReadQueueWatermarks(bsl::size_t lowWatermark,
                                                bsl::size_t highWatermark) = 0;
 
+    /// Request the implementation to start timestamping outgoing data if the
+    /// specified 'enable' flag is true. Otherwise, request the implementation
+    /// to stop timestamping outgoing data. Return the error.
+    virtual ntsa::Error timestampOutgoingData(bool enable);
+
     /// Enable copying from the socket buffers in the specified 'direction'.
     /// Return the error.
     virtual ntsa::Error relaxFlowControl(

--- a/groups/ntc/ntci/ntci_streamsocket.h
+++ b/groups/ntc/ntci/ntci_streamsocket.h
@@ -1463,6 +1463,10 @@ class StreamSocket : public ntsi::Descriptor,
     /// Return the error.
     virtual ntsa::Error deregisterSession() = 0;
 
+    /// Set the minimum number of bytes that must be available to send in order
+    /// to attempt a zero-copy send to the specified 'value'. Return the error.
+    virtual ntsa::Error setZeroCopyThreshold(bsl::size_t value);
+
     /// Set the write rate limiter to the specified 'rateLimiter'. Return
     /// the error.
     virtual ntsa::Error setWriteRateLimiter(
@@ -1506,6 +1510,11 @@ class StreamSocket : public ntsi::Descriptor,
     /// specified 'enable' flag is true. Otherwise, request the implementation
     /// to stop timestamping outgoing data. Return the error.
     virtual ntsa::Error timestampOutgoingData(bool enable);
+
+    /// Request the implementation to start timestamping incoming data if the
+    /// specified 'enable' flag is true. Otherwise, request the implementation
+    /// to stop timestamping outgoing data. Return the error.
+    virtual ntsa::Error timestampIncomingData(bool enable);
 
     /// Enable copying from the socket buffers in the specified 'direction'.
     /// Return the error.

--- a/groups/ntc/ntco/ntco_devpoll.cpp
+++ b/groups/ntc/ntco/ntco_devpoll.cpp
@@ -708,9 +708,7 @@ void Devpoll::flush()
 
         {
             LockGuard detachGuard(&d_generationMutex);
-            if (!d_chronology.hasAnyScheduledOrDeferred() &&
-                d_detachList.empty())
-            {
+            if (!d_chronology.hasAnyDeferred() && d_detachList.empty()) {
                 break;
             }
         }

--- a/groups/ntc/ntco/ntco_epoll.cpp
+++ b/groups/ntc/ntco/ntco_epoll.cpp
@@ -740,8 +740,10 @@ Epoll::Result::~Result()
 
 void Epoll::flush()
 {
-    while (d_chronology.hasAnyScheduledOrDeferred()) {
-        d_chronology.announce();
+    if (d_chronology.hasAnyScheduledOrDeferred()) {
+        do {
+            d_chronology.announce();
+        } while (d_chronology.hasAnyDeferred());
     }
 }
 

--- a/groups/ntc/ntco/ntco_eventport.cpp
+++ b/groups/ntc/ntco/ntco_eventport.cpp
@@ -689,7 +689,9 @@ void EventPort::specify(int*           events,
 void EventPort::flush()
 {
     if (d_chronology.hasAnyScheduledOrDeferred()) {
-        d_chronology.announce();
+        do {
+            d_chronology.announce();
+        } while (d_chronology.hasAnyDeferred());
     }
 }
 

--- a/groups/ntc/ntco/ntco_iocp.cpp
+++ b/groups/ntc/ntco/ntco_iocp.cpp
@@ -746,8 +746,10 @@ void Iocp::flush()
         NTCP_IOCP_LOG_EVENT_ABANDONED(event);
     }
 
-    while (d_chronology.hasAnyScheduledOrDeferred()) {
-        d_chronology.announce();
+    if (d_chronology.hasAnyScheduledOrDeferred()) {
+        do {
+            d_chronology.announce();
+        } while (d_chronology.hasAnyDeferred());
     }
 }
 

--- a/groups/ntc/ntco/ntco_ioring.cpp
+++ b/groups/ntc/ntco/ntco_ioring.cpp
@@ -4906,8 +4906,10 @@ void IoRing::flush()
         }
     }
 
-    while (d_chronology.hasAnyScheduledOrDeferred()) {
-        d_chronology.announce();
+    if (d_chronology.hasAnyScheduledOrDeferred()) {
+        do {
+            d_chronology.announce();
+        } while (d_chronology.hasAnyDeferred());
     }
 }
 

--- a/groups/ntc/ntco/ntco_kqueue.cpp
+++ b/groups/ntc/ntco/ntco_kqueue.cpp
@@ -692,8 +692,10 @@ Kqueue::Result::~Result()
 
 void Kqueue::flush()
 {
-    while (d_chronology.hasAnyScheduledOrDeferred()) {
-        d_chronology.announce();
+    if (d_chronology.hasAnyScheduledOrDeferred()) {
+        do {
+            d_chronology.announce();
+        } while (d_chronology.hasAnyDeferred());
     }
 }
 

--- a/groups/ntc/ntco/ntco_poll.cpp
+++ b/groups/ntc/ntco/ntco_poll.cpp
@@ -758,9 +758,7 @@ void Poll::flush()
 
         {
             LockGuard detachGuard(&d_detachMutex);
-            if (!d_chronology.hasAnyScheduledOrDeferred() &&
-                d_detachList.empty())
-            {
+            if (!d_chronology.hasAnyDeferred() && d_detachList.empty()) {
                 break;
             }
         }

--- a/groups/ntc/ntco/ntco_pollset.cpp
+++ b/groups/ntc/ntco/ntco_pollset.cpp
@@ -745,9 +745,7 @@ void Pollset::flush()
 
         {
             LockGuard detachGuard(&d_generationMutex);
-            if (!d_chronology.hasAnyScheduledOrDeferred() &&
-                d_detachList.empty())
-            {
+            if (!d_chronology.hasAnyDeferred() && d_detachList.empty()) {
                 break;
             }
         }

--- a/groups/ntc/ntco/ntco_select.cpp
+++ b/groups/ntc/ntco/ntco_select.cpp
@@ -733,9 +733,7 @@ void Select::flush()
 
         {
             LockGuard detachGuard(&d_detachMutex);
-            if (!d_chronology.hasAnyScheduledOrDeferred() &&
-                d_detachList.empty())
-            {
+            if (!d_chronology.hasAnyDeferred() && d_detachList.empty()) {
                 break;
             }
         }

--- a/groups/ntc/ntcq/ntcq_send.h
+++ b/groups/ntc/ntcq/ntcq_send.h
@@ -47,7 +47,7 @@ namespace BloombergLP {
 namespace ntcq {
 
 /// @internal @brief
-/// Describe the 64-bit unsigned integer incremented each time 
+/// Describe the 64-bit unsigned integer incremented each time
 /// 'ntci::Sender::send(...)' is called.
 ///
 /// @ingroup module_ntcq
@@ -65,7 +65,7 @@ class SendState
     ntcq::SendCounter d_counter;
 
 public:
-    /// Create new send state. 
+    /// Create new send state.
     SendState();
 
     /// Create new send state having the same value as the specified 'other'
@@ -190,7 +190,7 @@ class SendQueueEntry
 
   public:
     /// Create a new send queue entry. Optionally specify a 'basicAllocator'
-    /// used to supply memory. If 'basicAllocator' is 0, the currently 
+    /// used to supply memory. If 'basicAllocator' is 0, the currently
     /// installed default allocator is used.
     explicit SendQueueEntry(bslma::Allocator *basicAllocator = 0);
 
@@ -198,7 +198,7 @@ class SendQueueEntry
     /// 'other' object. Optionally specify a 'basicAllocator' used to supply
     /// memory. If 'basicAllocator' is 0, the currently installed default
     /// allocator is used.
-    SendQueueEntry(const SendQueueEntry& original, 
+    SendQueueEntry(const SendQueueEntry& original,
                    bslma::Allocator* basicAllocator = 0);
 
     /// Destroy this object.
@@ -518,7 +518,7 @@ SendQueueEntry::SendQueueEntry(bslma::Allocator* basicAllocator)
 }
 
 NTCCFG_INLINE
-SendQueueEntry::SendQueueEntry(const SendQueueEntry& original, 
+SendQueueEntry::SendQueueEntry(const SendQueueEntry& original,
                                bslma::Allocator* basicAllocator)
 : d_id(original.d_id)
 , d_token(original.d_token)
@@ -784,6 +784,8 @@ void SendQueue::popSize(bsl::size_t numBytes)
     BSLS_ASSERT(!d_entryList.empty());
 
     SendQueueEntry& entry = d_entryList.front();
+
+    entry.closeTimer();
 
     BSLS_ASSERT(entry.data());
     BSLS_ASSERT(entry.data()->size() == entry.length());

--- a/groups/ntc/ntcq/ntcq_send.h
+++ b/groups/ntc/ntcq/ntcq_send.h
@@ -47,124 +47,51 @@ namespace BloombergLP {
 namespace ntcq {
 
 /// @internal @brief
-/// Describe an entry in a send callback queue.
-///
-/// @par Thread Safety
-/// This class is thread safe.
+/// Describe the 64-bit unsigned integer incremented each time 
+/// 'ntci::Sender::send(...)' is called.
 ///
 /// @ingroup module_ntcq
-class SendCallbackQueueEntry
+typedef bsl::uint64_t SendCounter;
+
+/// @internal @brief
+/// Describe the state of a send operation.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntcq
+class SendState
 {
-    ntccfg::Object               d_object;
-    ntcs::CallbackState          d_state;
-    ntci::SendCallback           d_callback;
-    ntca::SendOptions            d_options;
-    bsl::shared_ptr<ntci::Timer> d_timer_sp;
+    ntcq::SendCounter d_counter;
 
-  private:
-    SendCallbackQueueEntry(const SendCallbackQueueEntry&) BSLS_KEYWORD_DELETED;
-    SendCallbackQueueEntry& operator=(const SendCallbackQueueEntry&)
-        BSLS_KEYWORD_DELETED;
+public:
+    /// Create new send state. 
+    SendState();
 
-  public:
-    /// Create a new send callback queue entry. Optionally specify a
-    /// 'basicAllocator' used to supply memory. If 'basicAllocator' is 0,
-    /// the currently installed default allocator is used.
-    explicit SendCallbackQueueEntry(bslma::Allocator* basicAllocator = 0);
+    /// Create new send state having the same value as the specified 'other'
+    /// object.
+    SendState(const SendState& original);
 
     /// Destroy this object.
-    ~SendCallbackQueueEntry();
+    ~SendState();
 
-    /// Clear the state of this entry.
-    void clear();
+    /// Assign the value of the specified 'other' object to this object. Return
+    /// a reference to this modifiable object.
+    SendState& operator=(const SendState& other);
 
-    /// Assign the specified 'callback' to be invoked on the specified
-    /// 'strand'.
-    void assign(const ntci::SendCallback& callback,
-                const ntca::SendOptions&  options);
+    /// Reset the value of this object to its value upon default construction.
+    void reset();
 
-    /// Set the timer to the specified 'timer'.
-    void setTimer(const bsl::shared_ptr<ntci::Timer>& timer);
+    /// Set the send counter to the specified 'value'.
+    void setCounter(ntcq::SendCounter value);
 
-    /// Clear the timer, if any.
-    void clearTimer();
-
-    const ntci::SendCallback& callback() const;
-
-    /// Return the criteria to invoke the callback.
-    const ntca::SendOptions& options() const;
-
-    /// Invoke the callback of the specified 'entry' for the specified
-    /// 'sender' and 'event'. If the specified 'defer' flag is false
-    /// and the requirements of the strand of the specified 'entry' permits
-    /// the callback to be invoked immediately by the 'strand', unlock the
-    /// specified 'mutex', invoke the callback, then relock the 'mutex'.
-    /// Otherwise, enqueue the invocation of the callback to be executed on
-    /// the strand of the 'entry', if defined, or by the specified
-    /// 'executor' otherwise.
-    static void dispatch(
-        const bsl::shared_ptr<ntcq::SendCallbackQueueEntry>& entry,
-        const bsl::shared_ptr<ntci::Sender>&                 sender,
-        const ntca::SendEvent&                               event,
-        const bsl::shared_ptr<ntci::Strand>&                 strand,
-        const bsl::shared_ptr<ntci::Executor>&               executor,
-        bool                                                 defer,
-        bslmt::Mutex*                                        mutex);
+    /// Return the send counter.
+    ntcq::SendCounter counter() const;
 
     /// Defines the traits of this type. These traits can be used to select,
     /// at compile-time, the most efficient algorithm to manipulate objects
     /// of this type.
-    NTCCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(SendCallbackQueueEntry);
-};
-
-/// @internal @brief
-/// Provide a pool of shared pointers to send callback queue entries.
-///
-/// @par Thread Safety
-/// This class is thread safe.
-///
-/// @ingroup module_ntcq
-class SendCallbackQueueEntryPool
-{
-    typedef bdlcc::SharedObjectPool<
-        ntcq::SendCallbackQueueEntry,
-        bdlcc::ObjectPoolFunctors::DefaultCreator,
-        bdlcc::ObjectPoolFunctors::Clear<ntcq::SendCallbackQueueEntry> >
-        Pool;
-
-    Pool d_pool;
-
-  private:
-    SendCallbackQueueEntryPool(const SendCallbackQueueEntryPool&)
-        BSLS_KEYWORD_DELETED;
-    SendCallbackQueueEntryPool& operator=(const SendCallbackQueueEntryPool&)
-        BSLS_KEYWORD_DELETED;
-
-  private:
-    /// Construct a new send callback queue entry at the specified
-    /// 'address' using the specified 'allocator' to supply memory.
-    static void construct(void* address, bslma::Allocator* allocator);
-
-  public:
-    /// Create a new object. Optionally specify a 'basicAllocator' used to
-    /// supply memory. If 'basicAllocator' is 0, the currently installed
-    /// default allocator is used.
-    explicit SendCallbackQueueEntryPool(bslma::Allocator* basicAllocator = 0);
-
-    /// Destroy this object.
-    ~SendCallbackQueueEntryPool();
-
-    /// Return a shared pointer to an send callback queue entry in the
-    /// pool having a default value. The resulting send callback queue
-    /// entry is automatically returned to this pool when its reference
-    /// count reaches zero.
-    bsl::shared_ptr<ntcq::SendCallbackQueueEntry> create();
-
-    /// Return the total number of objects in the pool.
-    bsl::size_t numObjects() const;
-
-    /// Return the number of un-allocated objects available in the pool.
-    bsl::size_t numObjectsAvailable() const;
+    NTCCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(SendState);
 };
 
 /// @internal @brief
@@ -184,8 +111,9 @@ class SendQueueEntry
     bsl::int64_t                            d_timestamp;
     bdlb::NullableValue<bsls::TimeInterval> d_deadline;
     bsl::shared_ptr<ntci::Timer>            d_timer_sp;
-    bsl::shared_ptr<SendCallbackQueueEntry> d_callbackEntry_sp;
+    ntci::SendCallback                      d_callback;
     bool                                    d_inProgress;
+    bool                                    d_zeroCopy;
 
   private:
     /// If this entry is batchable, append a reference to this data of this
@@ -261,8 +189,20 @@ class SendQueueEntry
                    const ntsa::SendOptions& options) const;
 
   public:
-    /// Create a new send queue entry.
-    SendQueueEntry();
+    /// Create a new send queue entry. Optionally specify a 'basicAllocator'
+    /// used to supply memory. If 'basicAllocator' is 0, the currently 
+    /// installed default allocator is used.
+    explicit SendQueueEntry(bslma::Allocator *basicAllocator = 0);
+
+    /// Create a new send queue entry having the same value as the specified
+    /// 'other' object. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    SendQueueEntry(const SendQueueEntry& original, 
+                   bslma::Allocator* basicAllocator = 0);
+
+    /// Destroy this object.
+    ~SendQueueEntry();
 
     /// Set the identifier used to internally time-out the queue entry to
     /// the specified 'id'.
@@ -302,13 +242,18 @@ class SendQueueEntry
     /// Set the timer to the specified 'timer'.
     void setTimer(const bsl::shared_ptr<ntci::Timer>& timer);
 
-    /// Set the callback entry to the specified 'callbackEntry'.
-    void setCallbackEntry(
-        const bsl::shared_ptr<SendCallbackQueueEntry>& callbackEntry);
+    /// Set the callback to the specified 'callback'.
+    void setCallback(const ntci::SendCallback& callback);
 
     /// Set the flag to indicate that the entry is now in-progress, i.e. its
-    /// data has been at least partially copied to the send buffer.
-    void setInProgress();
+    /// data has been at least partially copied to the send buffer, to the
+    /// specified 'inProgress' flag.
+    void setInProgress(bool inProgress);
+
+    /// Set the flag to indicate that at least some of a data of the entry
+    /// has been successfully sent with zero-copy semantics to the specified
+    /// 'zeroCopy' flag.
+    void setZeroCopy(bool zeroCopy);
 
     /// Close the timer, if any.
     void closeTimer();
@@ -346,15 +291,24 @@ class SendQueueEntry
     bsls::TimeInterval delay() const;
 
     /// Return the callback entry.
-    const bsl::shared_ptr<SendCallbackQueueEntry>& callbackEntry() const;
+    const ntci::SendCallback& callback() const;
 
     /// Return the flag that indicates whether the entry is now in-progress,
     /// i.e. its data has been at least partially copied to the send buffer.
     bool inProgress() const;
 
+    /// Return the flag to indicate that at least some of a data of the entry
+    /// has been successfully sent with zero-copy semantics.
+    bool zeroCopy() const;
+
     /// Return the flag that indicates the data representation of this entry
     /// is batchable with other similar representations.
     bool isBatchable() const;
+
+    /// Defines the traits of this type. These traits can be used to select,
+    /// at compile-time, the most efficient algorithm to manipulate objects
+    /// of this type.
+    NTCCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(SendQueueEntry);
 };
 
 /// @internal @brief
@@ -378,7 +332,6 @@ class SendQueue
     bsl::size_t                      d_watermarkHigh;
     bool                             d_watermarkHighWanted;
     bsl::uint64_t                    d_nextEntryId;
-    ntcq::SendCallbackQueueEntryPool d_callbackEntryPool;
     bslma::Allocator*                d_allocator_p;
 
   private:
@@ -393,9 +346,6 @@ class SendQueue
 
     /// Destroy this object.
     ~SendQueue();
-
-    /// Return a shared pointer to a new send callback queue entry.
-    bsl::shared_ptr<ntcq::SendCallbackQueueEntry> createCallbackEntry();
 
     /// Return the next entry identifier.
     bsl::uint64_t generateEntryId();
@@ -418,14 +368,14 @@ class SendQueue
     /// queue.
     void popSize(bsl::size_t numBytes);
 
-    /// Remove the entry having the specified 'id' and load its callback
-    /// entry into the specified 'result', if an entry with such an 'id' and
-    /// defined callback and defined deadline exists and has not already
-    /// had any portion of its data copied to the socket send buffer. Return
-    /// true if queue becomes empty as a result of this operation, otherwise
-    /// return false.
-    bool removeEntryId(bsl::shared_ptr<ntcq::SendCallbackQueueEntry>* result,
-                       bsl::uint64_t                                  id);
+    /// Remove the entry having the specified 'id' and load its callback into
+    /// the specified 'result', if an entry with such an 'id' and defined
+    /// callback and defined deadline exists and has not already had any
+    /// portion of its data copied to the socket send buffer. Return true if
+    /// queue becomes empty as a result of this operation, otherwise return
+    /// false.
+    bool removeEntryId(ntci::SendCallback* result,
+                       bsl::uint64_t       id);
 
     /// Remove the entry having the specified 'token' and load its callback
     /// entry into the specified 'result', if an entry with such a 'token'
@@ -433,14 +383,13 @@ class SendQueue
     /// its data copied to the socket send buffer. Return true if queue
     /// becomes empty as a result of this operation, otherwise return false.
     bool removeEntryToken(
-        bsl::shared_ptr<ntcq::SendCallbackQueueEntry>* result,
-        const ntca::SendToken&                         token);
+        ntci::SendCallback*    result,
+        const ntca::SendToken& token);
 
     /// Load into the specified 'result' any pending callback entries and
     /// clear the queue. Return true if the queue was non-empty, and false
     /// otherwise.
-    bool removeAll(
-        bsl::vector<bsl::shared_ptr<ntcq::SendCallbackQueueEntry> >* result);
+    bool removeAll(bsl::vector<ntci::SendCallback>* result);
 
     /// Set the data stored in the queue to the specified 'data'.
     void setData(const bsl::shared_ptr<bdlbb::Blob>& data);
@@ -508,60 +457,49 @@ class SendQueue
 };
 
 NTCCFG_INLINE
-void SendCallbackQueueEntry::assign(const ntci::SendCallback& callback,
-                                    const ntca::SendOptions&  options)
+SendState::SendState()
+: d_counter(0)
 {
-    d_callback = callback;
-    d_options  = options;
 }
 
 NTCCFG_INLINE
-void SendCallbackQueueEntry::setTimer(
-    const bsl::shared_ptr<ntci::Timer>& timer)
+SendState::SendState(const SendState& original)
+: d_counter(original.d_counter)
 {
-    d_timer_sp = timer;
 }
 
 NTCCFG_INLINE
-void SendCallbackQueueEntry::clearTimer()
+SendState::~SendState()
 {
-    if (d_timer_sp) {
-        d_timer_sp.reset();
-    }
-}
-NTCCFG_INLINE
-const ntci::SendCallback& SendCallbackQueueEntry::callback() const
-{
-    return d_callback;
 }
 
 NTCCFG_INLINE
-const ntca::SendOptions& SendCallbackQueueEntry::options() const
+SendState& SendState::operator=(const SendState& other)
 {
-    return d_options;
+    d_counter = other.d_counter;
+    return *this;
 }
 
 NTCCFG_INLINE
-bsl::shared_ptr<ntcq::SendCallbackQueueEntry> SendCallbackQueueEntryPool::
-    create()
+void SendState::reset()
 {
-    return d_pool.getObject();
+    d_counter = 0;
 }
 
 NTCCFG_INLINE
-bsl::size_t SendCallbackQueueEntryPool::numObjects() const
+void SendState::setCounter(ntcq::SendCounter value)
 {
-    return d_pool.numObjects();
+    d_counter = value;
 }
 
 NTCCFG_INLINE
-bsl::size_t SendCallbackQueueEntryPool::numObjectsAvailable() const
+ntcq::SendCounter SendState::counter() const
 {
-    return d_pool.numAvailableObjects();
+    return d_counter;
 }
 
 NTCCFG_INLINE
-SendQueueEntry::SendQueueEntry()
+SendQueueEntry::SendQueueEntry(bslma::Allocator* basicAllocator)
 : d_id(0)
 , d_token()
 , d_endpoint()
@@ -570,8 +508,31 @@ SendQueueEntry::SendQueueEntry()
 , d_timestamp(0)
 , d_deadline()
 , d_timer_sp()
-, d_callbackEntry_sp()
+, d_callback(basicAllocator)
 , d_inProgress(false)
+, d_zeroCopy(false)
+{
+}
+
+NTCCFG_INLINE
+SendQueueEntry::SendQueueEntry(const SendQueueEntry& original, 
+                               bslma::Allocator* basicAllocator)
+: d_id(original.d_id)
+, d_token(original.d_token)
+, d_endpoint(original.d_endpoint)
+, d_data_sp(original.d_data_sp)
+, d_length(original.d_length)
+, d_timestamp(original.d_timestamp)
+, d_deadline(original.d_deadline)
+, d_timer_sp(original.d_timer_sp)
+, d_callback(original.d_callback, basicAllocator)
+, d_inProgress(original.d_inProgress)
+, d_zeroCopy(original.d_zeroCopy)
+{
+}
+
+NTCCFG_INLINE
+SendQueueEntry::~SendQueueEntry()
 {
 }
 
@@ -642,23 +603,25 @@ NTCCFG_INLINE
 void SendQueueEntry::setTimer(const bsl::shared_ptr<ntci::Timer>& timer)
 {
     d_timer_sp = timer;
-
-    if (d_callbackEntry_sp) {
-        d_callbackEntry_sp->setTimer(timer);
-    }
 }
 
 NTCCFG_INLINE
-void SendQueueEntry::setCallbackEntry(
-    const bsl::shared_ptr<SendCallbackQueueEntry>& callbackEntry)
+void SendQueueEntry::setCallback(
+    const ntci::SendCallback& callback)
 {
-    d_callbackEntry_sp = callbackEntry;
+    d_callback = callback;
 }
 
 NTCCFG_INLINE
-void SendQueueEntry::setInProgress()
+void SendQueueEntry::setInProgress(bool inProgress)
 {
-    d_inProgress = true;
+    d_inProgress = inProgress;
+}
+
+NTCCFG_INLINE
+void SendQueueEntry::setZeroCopy(bool zeroCopy)
+{
+    d_zeroCopy = zeroCopy;
 }
 
 NTCCFG_INLINE
@@ -667,10 +630,6 @@ void SendQueueEntry::closeTimer()
     if (d_timer_sp) {
         d_timer_sp->close();
         d_timer_sp.reset();
-    }
-
-    if (d_callbackEntry_sp) {
-        d_callbackEntry_sp->clearTimer();
     }
 }
 
@@ -732,16 +691,21 @@ bsls::TimeInterval SendQueueEntry::delay() const
 }
 
 NTCCFG_INLINE
-const bsl::shared_ptr<SendCallbackQueueEntry>& SendQueueEntry::callbackEntry()
-    const
+const ntci::SendCallback& SendQueueEntry::callback() const
 {
-    return d_callbackEntry_sp;
+    return d_callback;
 }
 
 NTCCFG_INLINE
 bool SendQueueEntry::inProgress() const
 {
     return d_inProgress;
+}
+
+NTCCFG_INLINE
+bool SendQueueEntry::zeroCopy() const
+{
+    return d_zeroCopy;
 }
 
 NTCCFG_INLINE
@@ -756,12 +720,6 @@ bool SendQueueEntry::isBatchable() const
     }
 
     return true;
-}
-
-NTCCFG_INLINE
-bsl::shared_ptr<ntcq::SendCallbackQueueEntry> SendQueue::createCallbackEntry()
-{
-    return d_callbackEntryPool.create();
 }
 
 NTCCFG_INLINE
@@ -820,7 +778,7 @@ void SendQueue::popSize(bsl::size_t numBytes)
     BSLS_ASSERT(entry.data()->size() == entry.length());
 
     ntsa::DataUtil::pop(entry.data().get(), numBytes);
-    entry.setInProgress();
+    entry.setInProgress(true);
 
     BSLS_ASSERT(entry.length() >= numBytes);
     entry.setLength(entry.length() - numBytes);
@@ -833,7 +791,7 @@ void SendQueue::popSize(bsl::size_t numBytes)
 
 NTCCFG_INLINE
 bool SendQueue::removeEntryId(
-    bsl::shared_ptr<ntcq::SendCallbackQueueEntry>* result,
+    ntci::SendCallback* result,
     bsl::uint64_t                                  id)
 {
     result->reset();
@@ -853,8 +811,8 @@ bool SendQueue::removeEntryId(
                         d_size -= entry.length();
                     }
 
-                    if (entry.callbackEntry()) {
-                        *result = entry.callbackEntry();
+                    if (entry.callback()) {
+                        *result = entry.callback();
                     }
 
                     d_entryList.erase(it);
@@ -869,7 +827,7 @@ bool SendQueue::removeEntryId(
 
 NTCCFG_INLINE
 bool SendQueue::removeEntryToken(
-    bsl::shared_ptr<ntcq::SendCallbackQueueEntry>* result,
+    ntci::SendCallback* result,
     const ntca::SendToken&                         token)
 {
     result->reset();
@@ -889,8 +847,8 @@ bool SendQueue::removeEntryToken(
                         d_size -= entry.length();
                     }
 
-                    if (entry.callbackEntry()) {
-                        *result = entry.callbackEntry();
+                    if (entry.callback()) {
+                        *result = entry.callback();
                     }
 
                     d_entryList.erase(it);
@@ -905,7 +863,7 @@ bool SendQueue::removeEntryToken(
 
 NTCCFG_INLINE
 bool SendQueue::removeAll(
-    bsl::vector<bsl::shared_ptr<ntcq::SendCallbackQueueEntry> >* result)
+    bsl::vector<ntci::SendCallback>* result)
 {
     bool nonEmpty = !d_entryList.empty();
 
@@ -913,8 +871,8 @@ bool SendQueue::removeAll(
          ++it)
     {
         const ntcq::SendQueueEntry& entry = *it;
-        if (entry.callbackEntry()) {
-            result->push_back(entry.callbackEntry());
+        if (entry.callback()) {
+            result->push_back(entry.callback());
         }
     }
 

--- a/groups/ntc/ntcq/ntcq_send.h
+++ b/groups/ntc/ntcq/ntcq_send.h
@@ -245,6 +245,9 @@ class SendQueueEntry
     /// Set the callback to the specified 'callback'.
     void setCallback(const ntci::SendCallback& callback);
 
+    /// Set the callback to the empty callback.
+    void setCallback(bsl::nullptr_t);
+
     /// Set the flag to indicate that the entry is now in-progress, i.e. its
     /// data has been at least partially copied to the send buffer, to the
     /// specified 'inProgress' flag.
@@ -610,6 +613,12 @@ void SendQueueEntry::setCallback(
     const ntci::SendCallback& callback)
 {
     d_callback = callback;
+}
+
+NTCCFG_INLINE
+void SendQueueEntry::setCallback(bsl::nullptr_t)
+{
+    d_callback.reset();
 }
 
 NTCCFG_INLINE

--- a/groups/ntc/ntcq/ntcq_send.h
+++ b/groups/ntc/ntcq/ntcq_send.h
@@ -764,6 +764,8 @@ bool SendQueue::popEntry()
     {
         SendQueueEntry& entry = d_entryList.front();
 
+        entry.closeTimer();
+
         if (entry.data()) {
             BSLS_ASSERT(entry.length() > 0);
             BSLS_ASSERT(entry.length() == entry.data()->size());
@@ -801,14 +803,14 @@ void SendQueue::popSize(bsl::size_t numBytes)
 NTCCFG_INLINE
 bool SendQueue::removeEntryId(
     ntci::SendCallback* result,
-    bsl::uint64_t                                  id)
+    bsl::uint64_t       id)
 {
     result->reset();
 
     for (EntryList::iterator it = d_entryList.begin(); it != d_entryList.end();
          ++it)
     {
-        const ntcq::SendQueueEntry& entry = *it;
+        ntcq::SendQueueEntry& entry = *it;
 
         if (entry.id() == id) {
             if (!entry.deadline().isNull()) {
@@ -819,6 +821,8 @@ bool SendQueue::removeEntryId(
                         BSLS_ASSERT(d_size >= entry.length());
                         d_size -= entry.length();
                     }
+
+                    entry.closeTimer();
 
                     if (entry.callback()) {
                         *result = entry.callback();
@@ -836,15 +840,15 @@ bool SendQueue::removeEntryId(
 
 NTCCFG_INLINE
 bool SendQueue::removeEntryToken(
-    ntci::SendCallback* result,
-    const ntca::SendToken&                         token)
+    ntci::SendCallback*    result,
+    const ntca::SendToken& token)
 {
     result->reset();
 
     for (EntryList::iterator it = d_entryList.begin(); it != d_entryList.end();
          ++it)
     {
-        const ntcq::SendQueueEntry& entry = *it;
+        ntcq::SendQueueEntry& entry = *it;
 
         if (!entry.token().isNull()) {
             if (entry.token().value() == token) {
@@ -855,6 +859,8 @@ bool SendQueue::removeEntryToken(
                         BSLS_ASSERT(d_size >= entry.length());
                         d_size -= entry.length();
                     }
+
+                    entry.closeTimer();
 
                     if (entry.callback()) {
                         *result = entry.callback();
@@ -879,7 +885,10 @@ bool SendQueue::removeAll(
     for (EntryList::iterator it = d_entryList.begin(); it != d_entryList.end();
          ++it)
     {
-        const ntcq::SendQueueEntry& entry = *it;
+        ntcq::SendQueueEntry& entry = *it;
+
+        entry.closeTimer();
+
         if (entry.callback()) {
             result->push_back(entry.callback());
         }

--- a/groups/ntc/ntcq/ntcq_send.t.cpp
+++ b/groups/ntc/ntcq/ntcq_send.t.cpp
@@ -197,285 +197,6 @@ void EventUtil::processComplete(bsls::AtomicUint* numInvoked,
 
 NTCCFG_TEST_CASE(1)
 {
-    #if 0
-    // Concern: The pool of shared objects correctly creates a shared pointer
-    // to an entry, which is released back to the pool when its reference
-    // count reaches zero. The pool grows by one each time a new object must
-    // be created but no objects are available.
-
-    ntccfg::TestAllocator ta;
-    {
-        typedef ntcq::SendCallbackQueueEntry     Entry;
-        typedef ntcq::SendCallbackQueueEntryPool Pool;
-
-        // Create a pool an ensure it is initially empty.
-
-        Pool pool(&ta);
-
-        NTCCFG_TEST_EQ(pool.numObjects(), 0);
-        NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
-
-        // Allocate a shared object from the pool, ensure the pool is now
-        // managing one object, with zero objects free, then reset the
-        // shared pointer to the object, and ensure the shared object is
-        // released back to the pool.
-
-        {
-            bsl::shared_ptr<Entry> entry = pool.create();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 1);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
-
-            entry.reset();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 1);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
-        }
-
-        // Allocate another shared object from the pool and ensure the
-        // returned object is from the pool, the reset the shared pointer to
-        // return the object back to the pool.
-
-        {
-            bsl::shared_ptr<Entry> entry = pool.create();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 1);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
-
-            entry.reset();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 1);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
-        }
-
-        // Allocate two shared objects from the pool, and ensure the pool
-        // grows by one.
-
-        {
-            bsl::shared_ptr<Entry> entry1 = pool.create();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 1);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
-
-            bsl::shared_ptr<Entry> entry2 = pool.create();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 2);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
-
-            entry1.reset();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 2);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
-
-            entry2.reset();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 2);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 2);
-        }
-
-        // Allocate three shared objects from the pool, and ensure the pool
-        // grows by one.
-
-        {
-            bsl::shared_ptr<Entry> entry1 = pool.create();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 2);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
-
-            bsl::shared_ptr<Entry> entry2 = pool.create();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 2);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
-
-            bsl::shared_ptr<Entry> entry3 = pool.create();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 3);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 0);
-
-            entry1.reset();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 3);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 1);
-
-            entry2.reset();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 3);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 2);
-
-            entry3.reset();
-
-            NTCCFG_TEST_EQ(pool.numObjects(), 3);
-            NTCCFG_TEST_EQ(pool.numObjectsAvailable(), 3);
-        }
-    }
-    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
-    #endif
-}
-
-NTCCFG_TEST_CASE(2)
-{
-    #if 0
-    // Concern: The callback entry invokes the callback with the correct
-    // parameters, the correct number of times, when completed, canceled, and
-    // aborted, from within a context that allows the callback entry to be
-    // immediately executed.
-
-    ntccfg::TestAllocator ta;
-    {
-        typedef ntcq::SendCallbackQueueEntry Entry;
-
-        bsl::shared_ptr<ntci::Sender> sender;
-
-        bsl::shared_ptr<test::Strand> queue;
-        queue.createInplace(&ta, &ta);
-
-        bsl::shared_ptr<ntci::Strand>   strand   = queue;
-        bsl::shared_ptr<ntci::Executor> executor = strand;
-
-        ntca::SendEvent event;
-        event.setType(ntca::SendEventType::e_COMPLETE);
-
-        bslmt::Mutex                   mutex;
-        bslmt::LockGuard<bslmt::Mutex> lock(&mutex);
-
-        // Test announcement immediately.
-
-        {
-            bsl::shared_ptr<Entry> entry;
-            entry.createInplace(&ta, &ta);
-
-            bsls::AtomicUint numInvoked(0);
-
-            ntci::SendCallback sendCallback(
-                NTCCFG_BIND(&test::EventUtil::processComplete,
-                            &numInvoked,
-                            NTCCFG_BIND_PLACEHOLDER_1,
-                            NTCCFG_BIND_PLACEHOLDER_2));
-
-            ntca::SendOptions sendOptions;
-
-            entry->assign(sendCallback, sendOptions);
-
-            NTCCFG_TEST_EQ(numInvoked, 0);
-
-            Entry::dispatch(entry,
-                            sender,
-                            event,
-                            ntci::Strand::unspecified(),
-                            executor,
-                            false,
-                            &mutex);
-
-            NTCCFG_TEST_EQ(numInvoked, 1);
-
-            Entry::dispatch(entry,
-                            sender,
-                            event,
-                            ntci::Strand::unspecified(),
-                            executor,
-                            false,
-                            &mutex);
-
-            NTCCFG_TEST_EQ(numInvoked, 1);
-        }
-
-        // Test announcement through a strand.
-
-        {
-            bsl::shared_ptr<Entry> entry;
-            entry.createInplace(&ta, &ta);
-
-            bsls::AtomicUint numInvoked(0);
-
-            ntci::SendCallback sendCallback(
-                NTCCFG_BIND(&test::EventUtil::processComplete,
-                            &numInvoked,
-                            NTCCFG_BIND_PLACEHOLDER_1,
-                            NTCCFG_BIND_PLACEHOLDER_2),
-                strand);
-
-            ntca::SendOptions sendOptions;
-
-            entry->assign(sendCallback, sendOptions);
-
-            NTCCFG_TEST_EQ(numInvoked, 0);
-
-            Entry::dispatch(entry,
-                            sender,
-                            event,
-                            ntci::Strand::unspecified(),
-                            executor,
-                            false,
-                            &mutex);
-
-            NTCCFG_TEST_EQ(numInvoked, 0);
-            queue->drain();
-            NTCCFG_TEST_EQ(numInvoked, 1);
-
-            Entry::dispatch(entry,
-                            sender,
-                            event,
-                            ntci::Strand::unspecified(),
-                            executor,
-                            false,
-                            &mutex);
-
-            NTCCFG_TEST_EQ(numInvoked, 1);
-            queue->drain();
-            NTCCFG_TEST_EQ(numInvoked, 1);
-        }
-
-        // Test announcement forcing it to be deferred through an executor.
-
-        {
-            bsl::shared_ptr<Entry> entry;
-            entry.createInplace(&ta, &ta);
-
-            bsls::AtomicUint numInvoked(0);
-
-            ntci::SendCallback sendCallback(
-                NTCCFG_BIND(&test::EventUtil::processComplete,
-                            &numInvoked,
-                            NTCCFG_BIND_PLACEHOLDER_1,
-                            NTCCFG_BIND_PLACEHOLDER_2));
-
-            ntca::SendOptions sendOptions;
-
-            entry->assign(sendCallback, sendOptions);
-
-            NTCCFG_TEST_EQ(numInvoked, 0);
-
-            Entry::dispatch(entry,
-                            sender,
-                            event,
-                            ntci::Strand::unspecified(),
-                            executor,
-                            true,
-                            &mutex);
-
-            NTCCFG_TEST_EQ(numInvoked, 0);
-            queue->drain();
-            NTCCFG_TEST_EQ(numInvoked, 1);
-
-            Entry::dispatch(entry,
-                            sender,
-                            event,
-                            ntci::Strand::unspecified(),
-                            executor,
-                            true,
-                            &mutex);
-
-            NTCCFG_TEST_EQ(numInvoked, 1);
-            queue->drain();
-            NTCCFG_TEST_EQ(numInvoked, 1);
-        }
-    }
-    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
-    #endif
-}
-
-NTCCFG_TEST_CASE(3)
-{
     // Concern: Announcement of the low watermark is not authorized until the
     // queue is filled up to the high watermark then drained down the low
     // watermark. Announcement of the high watermark is authorized once the
@@ -581,7 +302,7 @@ NTCCFG_TEST_CASE(3)
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
-NTCCFG_TEST_CASE(4)
+NTCCFG_TEST_CASE(2)
 {
     // Concern: Batching next suitable entries: empty
 
@@ -602,7 +323,7 @@ NTCCFG_TEST_CASE(4)
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
-NTCCFG_TEST_CASE(5)
+NTCCFG_TEST_CASE(3)
 {
     // Concern: Batching next suitable entries: blob
 
@@ -648,7 +369,7 @@ NTCCFG_TEST_CASE(5)
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
-NTCCFG_TEST_CASE(6)
+NTCCFG_TEST_CASE(4)
 {
     // Concern: Batching next suitable entries: blob -> blob
 
@@ -726,7 +447,7 @@ NTCCFG_TEST_CASE(6)
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
-NTCCFG_TEST_CASE(7)
+NTCCFG_TEST_CASE(5)
 {
     // Concern: Batching next suitable entries: blob -> blob -> file -> blob
 
@@ -836,7 +557,7 @@ NTCCFG_TEST_CASE(7)
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
 
-NTCCFG_TEST_CASE(8)
+NTCCFG_TEST_CASE(6)
 {
     // Concern: Batching next suitable entries: limit maximum buffers to the
     // maximum number sendable per system call (to avoid EMSGBUF).
@@ -921,7 +642,5 @@ NTCCFG_TEST_DRIVER
     NTCCFG_TEST_REGISTER(4);
     NTCCFG_TEST_REGISTER(5);
     NTCCFG_TEST_REGISTER(6);
-    NTCCFG_TEST_REGISTER(7);
-    NTCCFG_TEST_REGISTER(8);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcq/ntcq_send.t.cpp
+++ b/groups/ntc/ntcq/ntcq_send.t.cpp
@@ -197,6 +197,7 @@ void EventUtil::processComplete(bsls::AtomicUint* numInvoked,
 
 NTCCFG_TEST_CASE(1)
 {
+    #if 0
     // Concern: The pool of shared objects correctly creates a shared pointer
     // to an entry, which is released back to the pool when its reference
     // count reaches zero. The pool grows by one each time a new object must
@@ -308,10 +309,12 @@ NTCCFG_TEST_CASE(1)
         }
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+    #endif
 }
 
 NTCCFG_TEST_CASE(2)
 {
+    #if 0
     // Concern: The callback entry invokes the callback with the correct
     // parameters, the correct number of times, when completed, canceled, and
     // aborted, from within a context that allows the callback entry to be
@@ -468,6 +471,7 @@ NTCCFG_TEST_CASE(2)
         }
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+    #endif
 }
 
 NTCCFG_TEST_CASE(3)

--- a/groups/ntc/ntcq/ntcq_zerocopy.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.cpp
@@ -48,7 +48,7 @@ void ZeroCopyEntry::match(const ntcq::ZeroCopyRange& complete)
     if (d_rangeSet.empty()) {
         ntcq::ZeroCopyRange required = d_range;
 
-        ntcq::ZeroCopyRange intersection = 
+        ntcq::ZeroCopyRange intersection =
             ntcq::ZeroCopyRange::intersect(required, complete);
 
         if (intersection.empty()) {
@@ -72,7 +72,7 @@ void ZeroCopyEntry::match(const ntcq::ZeroCopyRange& complete)
 
         return;
     }
-    
+
     RangeSet rangeSet(d_allocator_p);
     rangeSet.swap(d_rangeSet);
 
@@ -82,7 +82,7 @@ void ZeroCopyEntry::match(const ntcq::ZeroCopyRange& complete)
     for (; it != et; ++it) {
         ntcq::ZeroCopyRange required = *it;
 
-        ntcq::ZeroCopyRange intersection = 
+        ntcq::ZeroCopyRange intersection =
             ntcq::ZeroCopyRange::intersect(required, complete);
 
         if (intersection.empty()) {
@@ -196,7 +196,7 @@ ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter  group,
 }
 
 ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter         group,
-                                          const bdlbb::Blob&        data, 
+                                          const bdlbb::Blob&        data,
                                           const ntci::SendCallback& callback)
 {
     BSLS_ASSERT(d_waitList.empty() || d_waitList.front().group() < group);
@@ -223,7 +223,7 @@ ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter         group,
     return counter;
 }
 
-ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter group, 
+ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter group,
                                           const ntsa::Data& data)
 {
     BSLS_ASSERT(d_waitList.empty() || d_waitList.front().group() < group);
@@ -246,8 +246,8 @@ ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter group,
     return counter;
 }
 
-ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter         group, 
-                                          const ntsa::Data&         data, 
+ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter         group,
+                                          const ntsa::Data&         data,
                                           const ntci::SendCallback& callback)
 {
     BSLS_ASSERT(d_waitList.empty() || d_waitList.front().group() < group);
@@ -275,7 +275,7 @@ ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter         group,
 }
 
 ntcq::ZeroCopyCounter ZeroCopyQueue::push(
-    ntcq::SendCounter                  group, 
+    ntcq::SendCounter                  group,
     const bsl::shared_ptr<ntsa::Data>& data)
 {
     BSLS_ASSERT(d_waitList.empty() || d_waitList.front().group() < group);
@@ -295,7 +295,7 @@ ntcq::ZeroCopyCounter ZeroCopyQueue::push(
 
 ntcq::ZeroCopyCounter ZeroCopyQueue::push(
     ntcq::SendCounter                  group,
-    const bsl::shared_ptr<ntsa::Data>& data, 
+    const bsl::shared_ptr<ntsa::Data>& data,
     const ntci::SendCallback&          callback)
 {
     BSLS_ASSERT(d_waitList.empty() || d_waitList.front().group() < group);
@@ -320,6 +320,8 @@ ntcq::ZeroCopyCounter ZeroCopyQueue::push(
 ntcq::ZeroCopyCounter ZeroCopyQueue::push(ntcq::SendCounter group)
 {
     NTCCFG_WARNING_UNUSED(group);
+
+    BSLS_ASSERT(!d_waitList.empty());
 
     ntcq::ZeroCopyCounter counter = d_generator.next();
 
@@ -351,7 +353,7 @@ ntsa::Error ZeroCopyQueue::update(const ntsa::ZeroCopy& zeroCopy)
     ntcq::ZeroCopyRange zeroCopyRange = d_generator.update(zeroCopy);
 
     EntryList::iterator current = d_waitList.begin();
-    
+
     while (true) {
         if (current == d_waitList.end()) {
             break;
@@ -364,7 +366,7 @@ ntsa::Error ZeroCopyQueue::update(const ntsa::ZeroCopy& zeroCopy)
         }
 
         entry.match(zeroCopyRange);
-         
+
         if (entry.complete()) {
             if (entry.callback()) {
                 d_doneList.push_back(entry);

--- a/groups/ntc/ntcq/ntcq_zerocopy.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.cpp
@@ -337,6 +337,8 @@ void ZeroCopyQueue::frame(ntcq::SendCounter group)
 {
     NTCCFG_WARNING_UNUSED(group);
 
+    BSLS_ASSERT(!d_waitList.empty());
+
     ZeroCopyEntry& entry = d_waitList.back();
     BSLS_ASSERT(entry.group() == group);
 

--- a/groups/ntc/ntcq/ntcq_zerocopy.h
+++ b/groups/ntc/ntcq/ntcq_zerocopy.h
@@ -38,7 +38,7 @@ namespace ntcq {
 
 /// @internal @brief
 /// Describe the 64-bit unsigned integer incremented after each successfully
-/// zero-copy 'sendmsg' system call. 
+/// zero-copy 'sendmsg' system call.
 ///
 /// @details
 /// Some operating system implementations may internally use 32-bit unsigned
@@ -65,9 +65,9 @@ public:
     /// Create a new zero-copy range.
     ZeroCopyRange();
 
-    /// Create a new zero-copy range from the specified 'minCounter', 
+    /// Create a new zero-copy range from the specified 'minCounter',
     /// inclusive, to the specified 'maxCounter', exclusive.
-    ZeroCopyRange(ntcq::ZeroCopyCounter minCounter, 
+    ZeroCopyRange(ntcq::ZeroCopyCounter minCounter,
                   ntcq::ZeroCopyCounter maxCounter);
 
     /// Create a new zero-copy range having the same value as the specified
@@ -78,7 +78,7 @@ public:
     ~ZeroCopyRange();
 
     /// Assign the value of the specified 'other' object to this object. Return
-    /// a reference to this modifiable object. 
+    /// a reference to this modifiable object.
     ZeroCopyRange& operator=(const ZeroCopyRange& other);
 
     /// Reset the value of this object to its value upon default construction.
@@ -98,10 +98,10 @@ public:
     /// Return the maximum zero-copy counter of the range, exclusive.
     ntcq::ZeroCopyCounter maxCounter() const;
 
-    /// Return the number of contiguous counter represented by this range. 
+    /// Return the number of contiguous counter represented by this range.
     bsl::size_t size() const;
-    
-    /// Return true if the range is empty, otherwise return false. 
+
+    /// Return true if the range is empty, otherwise return false.
     bool empty() const;
 
     /// Format this object to the specified output 'stream' at the
@@ -120,8 +120,8 @@ public:
                         int           spacesPerLevel = 4) const;
 
     /// Return the range that is the intersection of the specified 'lhs' and
-    /// 'rhs' ranges. 
-    static ZeroCopyRange intersect(const ZeroCopyRange& lhs, 
+    /// 'rhs' ranges.
+    static ZeroCopyRange intersect(const ZeroCopyRange& lhs,
                                    const ZeroCopyRange& rhs);
 
     /// Calculate the range that is the difference between the specified 'lhs'
@@ -129,9 +129,9 @@ public:
     /// specified 'result' and load the empty range into the specified
     /// 'overflow'. Otherwise, load the lesser difference into 'result' and the
     /// greater difference into the specified 'overflow'.
-    static void difference(ZeroCopyRange*       result, 
+    static void difference(ZeroCopyRange*       result,
                            ZeroCopyRange*       overflow,
-                           const ZeroCopyRange& lhs, 
+                           const ZeroCopyRange& lhs,
                            const ZeroCopyRange& rhs);
 
     /// Defines the traits of this type. These traits can be used to select,
@@ -188,14 +188,14 @@ class ZeroCopyEntry
     /// 'original' object. Optionally specify a 'basicAllocator' used to supply
     /// memory. If 'basicAllocator' is 0, the currently installed default
     /// allocator is used.
-    ZeroCopyEntry(const ZeroCopyEntry& original, 
+    ZeroCopyEntry(const ZeroCopyEntry& original,
                   bslma::Allocator*    basicAllocator = 0);
 
     /// Destroy this object.
     ~ZeroCopyEntry();
 
     /// Assign the value of the specified 'other' object to this object. Return
-    /// a reference to this modifiable object. 
+    /// a reference to this modifiable object.
     ZeroCopyEntry& operator=(const ZeroCopyEntry& other);
 
     /// Set the identifier of the data to the specified 'group'.
@@ -205,19 +205,19 @@ class ZeroCopyEntry
     /// 'counter'.
     void setMinCounter(ntcq::ZeroCopyCounter counter);
 
-    /// Set the maximum zero-copy counter needed, inclusive, to the specified
+    /// Set the maximum zero-copy counter needed, exclusive, to the specified
     /// 'counter'.
     void setMaxCounter(ntcq::ZeroCopyCounter counter);
 
-    /// Set the flag that indicates all portions of the data have been 
+    /// Set the flag that indicates all portions of the data have been
     /// sent (zero-copied or not), so that no further zero-copy counters are
-    /// expected, to the specified 'framed' value. 
+    /// expected, to the specified 'framed' value.
     void setFramed(bool framed);
 
-    /// Set the data transmitted for the group to the specified 'data'. 
+    /// Set the data transmitted for the group to the specified 'data'.
     void setData(const bsl::shared_ptr<ntsa::Data>& data);
 
-    /// Set the error encountered during transmission to the specified 'error'. 
+    /// Set the error encountered during transmission to the specified 'error'.
     void setError(const ntsa::Error& error);
 
     /// Set the callback invoked when the data has been completely transmitted
@@ -227,10 +227,10 @@ class ZeroCopyEntry
     /// Match the specified 'complete' zero-copy counters against the zero-copy
     /// counters required to complete this entry, remove the intersection from
     /// those needed, and if the result is the empty set indicate the entry is
-    /// complete. 
+    /// complete.
     void match(const ntcq::ZeroCopyRange& complete);
 
-    /// Return the identifier of the data. 
+    /// Return the identifier of the data.
     ntcq::SendCounter group() const;
 
     /// Return the minimum zero-copy counter needed, inclusive.
@@ -239,20 +239,20 @@ class ZeroCopyEntry
     /// Return the maximum zero-copy counter needed, inclusive.
     ntcq::ZeroCopyCounter maxCounter() const;
 
-    /// Return the flag that indicates all portions of the data have been 
+    /// Return the flag that indicates all portions of the data have been
     /// sent (zero-copied or not), so that no further zero-copy counters are
-    /// expected. 
+    /// expected.
     bool framed() const;
 
     /// Return the flag that indicates all portions of the data that have been
-    /// (or will be) zero-copied are complete. 
+    /// (or will be) zero-copied are complete.
     bool complete() const;
 
-    /// Return the error encountered during transmission, if any. 
+    /// Return the error encountered during transmission, if any.
     ntsa::Error error() const;
 
-    /// Return the callback invoked when the data has been completely 
-    /// transmitted. 
+    /// Return the callback invoked when the data has been completely
+    /// transmitted.
     const ntci::SendCallback& callback() const;
 
     /// Return the allocator used to supply memory.
@@ -297,7 +297,7 @@ class ZeroCopyCounterGenerator
     ntcq::ZeroCopyCounter d_next;
     ntcq::ZeroCopyCounter d_bias;
     ntcq::ZeroCopyCounter d_generation;
-    
+
 private:
     ZeroCopyCounterGenerator(
         const ZeroCopyCounterGenerator&) BSLS_KEYWORD_DELETED;
@@ -305,7 +305,7 @@ private:
         const ZeroCopyCounterGenerator&) BSLS_KEYWORD_DELETED;
 
 public:
-    /// Create a new zero copy counter generator from the default epoch of 
+    /// Create a new zero copy counter generator from the default epoch of
     /// zero.
     ZeroCopyCounterGenerator();
 
@@ -313,7 +313,7 @@ public:
     ~ZeroCopyCounterGenerator();
 
     /// Configure the generator to return the specified 'next' counter in the
-    /// specified 32-bit wraparound 'generation'. 
+    /// specified 32-bit wraparound 'generation'.
     void configure(ntcq::ZeroCopyCounter next,
                    bsl::size_t           generation);
 
@@ -326,7 +326,7 @@ public:
 };
 
 /// @internal @brief
-/// Provide a queue of operations requested to be zero-copied, and a 
+/// Provide a queue of operations requested to be zero-copied, and a
 /// correlation mechanism to learn when they are complete.
 ///
 /// @par Thread Safety
@@ -335,8 +335,7 @@ public:
 /// @ingroup module_ntcq
 class ZeroCopyQueue
 {
-    typedef bsl::list<ntcq::ZeroCopyEntry>   EntryList;
-    typedef bsl::vector<ntcq::ZeroCopyEntry> EntryVector;
+    typedef bsl::list<ntcq::ZeroCopyEntry> EntryList;
 
     ntcq::ZeroCopyCounterGenerator  d_generator;
     EntryList                       d_waitList;
@@ -365,33 +364,33 @@ class ZeroCopyQueue
     /// with this entry.
     ntcq::ZeroCopyCounter push(ntcq::SendCounter  group,
                                const bdlbb::Blob& data);
-    
+
     /// Append a new zero-copy entry for the specified 'data' sent as part of
     /// the specified 'group'. When sending the 'data' is complete, the
     /// specified 'callback' should be invoked. Return the first zero-copy
     /// counter associated with this entry.
     ntcq::ZeroCopyCounter push(ntcq::SendCounter         group,
-                               const bdlbb::Blob&        data, 
+                               const bdlbb::Blob&        data,
                                const ntci::SendCallback& callback);
 
     /// Append a new zero-copy entry for the specified 'data' sent as part of
     /// the specified 'group'. Return the first zero-copy counter associated
     /// with this entry.
-    ntcq::ZeroCopyCounter push(ntcq::SendCounter group, 
+    ntcq::ZeroCopyCounter push(ntcq::SendCounter group,
                                const ntsa::Data& data);
-    
+
     /// Append a new zero-copy entry for the specified 'data' sent as part of
     /// the specified 'group'. When sending the 'data' is complete, the
     /// specified 'callback' should be invoked. Return the first zero-copy
     /// counter associated with this entry.
-    ntcq::ZeroCopyCounter push(ntcq::SendCounter         group, 
-                               const ntsa::Data&         data, 
+    ntcq::ZeroCopyCounter push(ntcq::SendCounter         group,
+                               const ntsa::Data&         data,
                                const ntci::SendCallback& callback);
 
     /// Append a new zero-copy entry for the specified 'data' sent as part of
     /// the specified 'group'. Return the first zero-copy counter associated
     /// with this entry.
-    ntcq::ZeroCopyCounter push(ntcq::SendCounter                  group, 
+    ntcq::ZeroCopyCounter push(ntcq::SendCounter                  group,
                                const bsl::shared_ptr<ntsa::Data>& data);
 
     /// Append a new zero-copy entry the specified 'data' sent as part of the
@@ -399,7 +398,7 @@ class ZeroCopyQueue
     /// 'callback' should be invoked. Return the first zero-copy counter
     /// associated with this entry.
     ntcq::ZeroCopyCounter push(ntcq::SendCounter                  group,
-                               const bsl::shared_ptr<ntsa::Data>& data, 
+                               const bsl::shared_ptr<ntsa::Data>& data,
                                const ntci::SendCallback&          callback);
 
     /// Extend the last zero-copy entry sent as part of the specified 'group'.
@@ -416,12 +415,12 @@ class ZeroCopyQueue
 
     /// Pop the oldest, completed entry and load its callback, if any, into the
     /// specified 'result'. Return true if such and entry and callback exists,
-    /// otherwise return false. 
+    /// otherwise return false.
     bool pop(ntci::SendCallback* result);
 
     /// Pop each completed entry and append its callback, if any, into the
     /// specified 'result'. Return true if such and entry and callback exists,
-    /// otherwise return false. 
+    /// otherwise return false.
     bool pop(bsl::vector<ntci::SendCallback>* result);
 
     /// Remove all entries from the queue.
@@ -438,7 +437,7 @@ class ZeroCopyQueue
     void load(bsl::vector<ntcq::ZeroCopyEntry>* result) const;
 
     /// Return true if the queue a completed entry with a callback, otherwise
-    /// return false. 
+    /// return false.
     bool ready() const;
 
     /// Defines the traits of this type. These traits can be used to select,
@@ -455,12 +454,12 @@ ZeroCopyRange::ZeroCopyRange()
 }
 
 NTCCFG_INLINE
-ZeroCopyRange::ZeroCopyRange(ntcq::ZeroCopyCounter minCounter, 
+ZeroCopyRange::ZeroCopyRange(ntcq::ZeroCopyCounter minCounter,
                              ntcq::ZeroCopyCounter maxCounter)
 : d_minCounter(minCounter)
 , d_maxCounter(maxCounter)
 {
-}                        
+}
 
 NTCCFG_INLINE
 ZeroCopyRange::ZeroCopyRange(const ZeroCopyRange& original)
@@ -519,14 +518,14 @@ bsl::size_t ZeroCopyRange::size() const
     return static_cast<bsl::size_t>(d_maxCounter - d_minCounter);
 }
 
-NTCCFG_INLINE 
+NTCCFG_INLINE
 bool ZeroCopyRange::empty() const
 {
     return d_minCounter == d_maxCounter;
 }
 
 NTCCFG_INLINE
-ZeroCopyRange ZeroCopyRange::intersect(const ZeroCopyRange& lhs, 
+ZeroCopyRange ZeroCopyRange::intersect(const ZeroCopyRange& lhs,
                                        const ZeroCopyRange& rhs)
 {
     ZeroCopyRange result;
@@ -553,7 +552,7 @@ ZeroCopyRange ZeroCopyRange::intersect(const ZeroCopyRange& lhs,
 }
 
 NTCCFG_INLINE
-void ZeroCopyRange::difference(ZeroCopyRange*       result, 
+void ZeroCopyRange::difference(ZeroCopyRange*       result,
                                ZeroCopyRange*       overflow,
                                const ZeroCopyRange& lhs,
                                const ZeroCopyRange& rhs)
@@ -561,13 +560,13 @@ void ZeroCopyRange::difference(ZeroCopyRange*       result,
     result->reset();
     overflow->reset();
 
-    if (rhs.minCounter() <= lhs.minCounter() && 
-        rhs.maxCounter() >= lhs.maxCounter()) 
+    if (rhs.minCounter() <= lhs.minCounter() &&
+        rhs.maxCounter() >= lhs.maxCounter())
     {
         return;
     }
 
-    if (lhs.minCounter() < rhs.minCounter()) { 
+    if (lhs.minCounter() < rhs.minCounter()) {
         result->setMinCounter(lhs.minCounter());
         result->setMaxCounter(bsl::min(lhs.maxCounter(), rhs.minCounter()));
     }
@@ -597,7 +596,7 @@ bsl::ostream& operator<<(bsl::ostream& stream, const ZeroCopyRange& object)
 NTCCFG_INLINE
 bool operator==(const ZeroCopyRange& lhs, const ZeroCopyRange& rhs)
 {
-    return lhs.minCounter() == rhs.minCounter() && 
+    return lhs.minCounter() == rhs.minCounter() &&
            lhs.maxCounter() == rhs.maxCounter();
 }
 
@@ -621,7 +620,7 @@ ZeroCopyEntry::ZeroCopyEntry(bslma::Allocator* basicAllocator)
 }
 
 NTCCFG_INLINE
-ZeroCopyEntry::ZeroCopyEntry(const ZeroCopyEntry& original, 
+ZeroCopyEntry::ZeroCopyEntry(const ZeroCopyEntry& original,
                              bslma::Allocator*    basicAllocator)
 : d_group(original.d_group)
 , d_range(original.d_range)
@@ -782,7 +781,7 @@ NTCCFG_INLINE
 void ZeroCopyCounterGenerator::configure(ntcq::ZeroCopyCounter next,
                                          bsl::size_t           generation)
 {
-    const ntcq::ZeroCopyCounter k_UINT32_MAX = 
+    const ntcq::ZeroCopyCounter k_UINT32_MAX =
         static_cast<ntcq::ZeroCopyCounter>(
             bsl::numeric_limits<bsl::uint32_t>::max());
 
@@ -801,14 +800,14 @@ NTCCFG_INLINE
 ntcq::ZeroCopyRange ZeroCopyCounterGenerator::update(
     const ntsa::ZeroCopy& zeroCopy)
 {
-    const ntcq::ZeroCopyCounter k_UINT32_MAX = 
+    const ntcq::ZeroCopyCounter k_UINT32_MAX =
         static_cast<ntcq::ZeroCopyCounter>(
             bsl::numeric_limits<bsl::uint32_t>::max());
 
-    const ntcq::ZeroCopyCounter zeroCopyFrom = 
+    const ntcq::ZeroCopyCounter zeroCopyFrom =
         static_cast<ntcq::ZeroCopyCounter>(zeroCopy.from());
 
-    const ntcq::ZeroCopyCounter zeroCopyThru = 
+    const ntcq::ZeroCopyCounter zeroCopyThru =
         static_cast<ntcq::ZeroCopyCounter>(zeroCopy.thru());
 
     const ntcq::ZeroCopyCounter offset = d_bias + d_generation;
@@ -816,7 +815,7 @@ ntcq::ZeroCopyRange ZeroCopyCounterGenerator::update(
     ntcq::ZeroCopyRange zeroCopyRange;
 
     if (zeroCopyFrom > zeroCopyThru) {
-        const ntcq::ZeroCopyCounter size = 
+        const ntcq::ZeroCopyCounter size =
             static_cast<ntcq::ZeroCopyCounter>(
                 (k_UINT32_MAX - zeroCopyFrom) + zeroCopyThru + 2);
 

--- a/groups/ntc/ntcq/ntcq_zerocopy.h
+++ b/groups/ntc/ntcq/ntcq_zerocopy.h
@@ -809,7 +809,7 @@ ntcq::ZeroCopyRange ZeroCopyCounterGenerator::update(
         static_cast<ntcq::ZeroCopyCounter>(zeroCopy.from());
 
     const ntcq::ZeroCopyCounter zeroCopyThru = 
-        static_cast<ntcq::ZeroCopyCounter>(zeroCopy.to());
+        static_cast<ntcq::ZeroCopyCounter>(zeroCopy.thru());
 
     const ntcq::ZeroCopyCounter offset = d_bias + d_generation;
 

--- a/groups/ntc/ntcq/ntcq_zerocopy.h
+++ b/groups/ntc/ntcq/ntcq_zerocopy.h
@@ -30,38 +30,77 @@ BSLS_IDENT("$Id: $")
 namespace BloombergLP {
 namespace ntcq {
 
+/// @internal @brief
+/// Describe an entry in a zero-copy queue.
+///
+/// @par Thread Safety
+/// This class is not thread safe.
+///
+/// @ingroup module_ntcq
 class ZeroCopyEntry
 {
-    typedef bsl::vector<ntci::SendCallback> Callbacks;
+    typedef bsl::vector<ntci::SendCallback> CallbackVector;
 
-    Callbacks                   d_callbacks;
-    ntca::SendContext           d_sendContext;
-    bsl::shared_ptr<ntsa::Data> d_data_sp;
     bsl::uint32_t               d_id;
+    bsl::shared_ptr<ntsa::Data> d_data_sp;
+    ntca::SendEvent             d_event;
+    CallbackVector              d_callbacks;
     bslma::Allocator*           d_allocator_p;
 
   public:
-    ZeroCopyEntry(bslma::Allocator* allocator = 0);
-    ZeroCopyEntry(const ZeroCopyEntry& other, bslma::Allocator* allocator);
+    /// Create a new zero-copy entry. Optionally specify a 'basicAllocator'
+    /// used to supply memory. If 'basicAllocator' is 0, the currently
+    /// installed default allocator is used.
+    explicit ZeroCopyEntry(bslma::Allocator* basicAllocator = 0);
+
+    /// Create a new zero-copy entry having the same value as the specified
+    /// 'original' object. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    ZeroCopyEntry(const ZeroCopyEntry& original, 
+                  bslma::Allocator*    basicAllocator = 0);
 
     /// Destroy this object.
     ~ZeroCopyEntry();
 
-    void setCallback(const ntci::SendCallback& callback);
+    /// Set the identifier of the zero-copy entry to the specified 'id'.
     void setId(const bsl::uint32_t id);
+
+    /// Set the data transmitted to the specified 'data'. 
     void setData(const bsl::shared_ptr<ntsa::Data>& data);
-    void dispatch(const ntca::SendEventType::Value       eventType,
-                  const bsl::shared_ptr<ntci::Sender>&   sender,
+
+    /// Set the error encountered during transmission to the specified 'error'. 
+    void setError(const ntsa::Error& error);
+
+    /// Set the callback invoked when the data has been completely transmitted
+    /// to the specified 'callback'.
+    void addCallback(const ntci::SendCallback& callback);
+
+    /// Invoke all callbacks for the specified 'sender'. If the specified
+    /// 'defer' flag is false and the requirements of the strand of the
+    /// specified 'entry' permits the callback to be invoked immediately by the
+    /// 'strand', unlock the specified 'mutex', invoke the callback, then
+    /// relock the 'mutex'. Otherwise, enqueue the invocation of the callback
+    /// to be executed on the strand of the 'entry', if defined, or by the
+    /// specified 'executor' otherwise.
+    void dispatch(const bsl::shared_ptr<ntci::Sender>&   sender,
                   const bsl::shared_ptr<ntci::Strand>&   strand,
                   const bsl::shared_ptr<ntci::Executor>& executor,
                   bool                                   defer,
                   bslmt::Mutex*                          mutex);
 
-    ntca::SendContext&        context();
-    bsl::uint32_t             id() const;
+    /// Return the identifier of the zero-copy entry. 
+    bsl::uint32_t id() const;
+
+    /// Return the send context.
+    const ntca::SendContext& context() const;
+
     /// Return the allocator used to supply memory.
     bslma::Allocator* allocator() const;
 
+    /// Defines the traits of this type. These traits can be used to select,
+    /// at compile-time, the most efficient algorithm to manipulate objects
+    /// of this type.
     NTCCFG_DECLARE_NESTED_USES_ALLOCATOR_TRAITS(ZeroCopyEntry);
 };
 

--- a/groups/ntc/ntcq/ntcq_zerocopy.h
+++ b/groups/ntc/ntcq/ntcq_zerocopy.h
@@ -520,7 +520,7 @@ void ZeroCopyRange::difference(ZeroCopyRange*       result,
     // RHS: --------------
 
     if (rhs.minCounter() <= lhs.minCounter() && 
-        rhs.maxCounter() >= rhs.maxCounter()) 
+        rhs.maxCounter() >= lhs.maxCounter()) 
     {
         return;
     }
@@ -543,7 +543,12 @@ void ZeroCopyRange::difference(ZeroCopyRange*       result,
 
     // Aggregate
 
-    if (overflow->minCounter() == result->maxCounter()) {
+    if (result->empty()) {
+        result->setMinCounter(overflow->minCounter());
+        result->setMaxCounter(overflow->maxCounter());
+        overflow->reset();
+    }
+    else if (overflow->minCounter() == result->maxCounter()) {
         result->setMaxCounter(overflow->maxCounter());
         overflow->reset();
     }

--- a/groups/ntc/ntcq/ntcq_zerocopy.h
+++ b/groups/ntc/ntcq/ntcq_zerocopy.h
@@ -290,7 +290,8 @@ bsl::ostream& operator<<(bsl::ostream& stream, const ZeroCopyEntry& object);
 /// @ingroup module_ntcq
 class ZeroCopyQueue
 {
-    typedef bsl::vector<ZeroCopyEntry> EntryList;
+    typedef bsl::list<ZeroCopyEntry>   EntryList;
+    typedef bsl::vector<ZeroCopyEntry> EntryVector;
 
     ntcq::ZeroCopyCounter           d_counter;
     ntcq::ZeroCopyCounter           d_bias;

--- a/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
@@ -1222,7 +1222,6 @@ NTCCFG_TEST_CASE(13)
         // [ 0 0 0 0 0 0 0 0 0 0 1 1 1 1 1 1 1 1 1 1 2 ]
         // [ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 ]
         // [ X X X X X X X Y Y Y Y Y Y Y Z Z Z Z Z Z Z ]
-
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -1242,7 +1241,9 @@ NTCCFG_TEST_CASE(14)
 
         ntcq::ZeroCopyQueue zeroCopyQueue(dataPool, &ta);
 
+        NTCCFG_WARNING_UNUSED(zeroCopyQueue);
 
+        // TODO
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }

--- a/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
@@ -458,6 +458,8 @@ NTCCFG_TEST_CASE(3)
         const bsl::uint64_t k_U64_UINT32_MAX = 
             bsl::numeric_limits<bsl::uint32_t>::max();
 
+        // Test basic operation.
+
         {
             ntcq::ZeroCopyCounterGenerator generator;
             ntcq::ZeroCopyCounter          counter = 0;
@@ -477,6 +479,8 @@ NTCCFG_TEST_CASE(3)
             NTCCFG_TEST_EQ(range.minCounter(), 0);
             NTCCFG_TEST_EQ(range.maxCounter(), 4);
         }
+
+        // Test 32-bit wraparound incrementing by intervals of size 1.
 
         {
             ntcq::ZeroCopyCounterGenerator generator;
@@ -547,6 +551,141 @@ NTCCFG_TEST_CASE(3)
 
                 NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX + 2);
                 NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 2 + 1);
+            }
+        }
+
+        // Test 32-bit wraparound incrementing an intervals of size 2, ending
+        // on UINT_MAX.
+
+        {
+            ntcq::ZeroCopyCounterGenerator generator;
+            ntcq::ZeroCopyCounter          counter = 0;
+
+            generator.configure(k_U64_UINT32_MAX - 2, 0);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX - 2);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX - 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX + 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX + 2);
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(k_U32_UINT32_MAX - 1, 
+                                   k_U32_UINT32_MAX, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX - 1);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 1);
+            }
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(0, 
+                                   1, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX + 1);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 3);
+            }
+        }
+
+        // Test 32-bit wraparound incrementing an intervals of size 2, starting
+        // on UINT_MAX.
+
+        {
+            ntcq::ZeroCopyCounterGenerator generator;
+            ntcq::ZeroCopyCounter          counter = 0;
+
+            generator.configure(k_U64_UINT32_MAX - 2, 0);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX - 2);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX - 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX + 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX + 2);
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(k_U32_UINT32_MAX, 
+                                   0, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 2);
+            }
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(1, 
+                                   2, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX + 2);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 4);
+            }
+        }
+
+        // Test 32-bit wraparound incrementing an intervals of size 3, spanning
+        // UINT_MAX.
+
+        {
+            ntcq::ZeroCopyCounterGenerator generator;
+            ntcq::ZeroCopyCounter          counter = 0;
+
+            generator.configure(k_U64_UINT32_MAX - 2, 0);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX - 2);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX - 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX + 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX + 2);
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(k_U32_UINT32_MAX - 1, 
+                                   0, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX - 1);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 2);
+            }
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(1, 
+                                   2, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX + 2);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 4);
             }
         }
     }

--- a/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
@@ -452,7 +452,103 @@ NTCCFG_TEST_CASE(3)
 
     ntccfg::TestAllocator ta;
     {
-        // TODO
+        const bsl::uint32_t k_U32_UINT32_MAX = 
+            bsl::numeric_limits<bsl::uint32_t>::max();
+
+        const bsl::uint64_t k_U64_UINT32_MAX = 
+            bsl::numeric_limits<bsl::uint32_t>::max();
+
+        {
+            ntcq::ZeroCopyCounterGenerator generator;
+            ntcq::ZeroCopyCounter          counter = 0;
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, 0);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, 2);
+
+            ntcq::ZeroCopyRange range = 
+                generator.update(ntsa::ZeroCopy(0, 3, 1));
+
+            NTCCFG_TEST_EQ(range.minCounter(), 0);
+            NTCCFG_TEST_EQ(range.maxCounter(), 4);
+        }
+
+        {
+            ntcq::ZeroCopyCounterGenerator generator;
+            ntcq::ZeroCopyCounter          counter = 0;
+
+            generator.configure(k_U64_UINT32_MAX - 2, 0);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX - 2);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX - 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX + 1);
+
+            counter = generator.next();
+            NTCCFG_TEST_EQ(counter, k_U64_UINT32_MAX + 2);
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(k_U32_UINT32_MAX - 2, 
+                                   k_U32_UINT32_MAX - 2, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX - 2);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX - 2 + 1);
+            }
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(k_U32_UINT32_MAX - 1, 
+                                   k_U32_UINT32_MAX - 1, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX - 1);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX - 1 + 1);
+            }
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(k_U32_UINT32_MAX + 0, 
+                                   k_U32_UINT32_MAX + 0, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX + 0);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 0 + 1);
+            }
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(0, 
+                                   0, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX + 1);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 1 + 1);
+            }
+
+            {
+                ntcq::ZeroCopyRange range = generator.update(
+                    ntsa::ZeroCopy(1, 
+                                   1, 
+                                   1));
+
+                NTCCFG_TEST_EQ(range.minCounter(), k_U64_UINT32_MAX + 2);
+                NTCCFG_TEST_EQ(range.maxCounter(), k_U64_UINT32_MAX + 2 + 1);
+            }
+        }
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }

--- a/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
@@ -14,6 +14,7 @@
 // limitations under the License.
 
 #include <ntcq_zerocopy.h>
+#include <ntcs_datapool.h>
 
 #include <ntccfg_test.h>
 
@@ -22,6 +23,124 @@
 using namespace BloombergLP;
 
 NTCCFG_TEST_CASE(1)
+{
+    // Concern:
+    // Plan:
+
+    // Case 1: (invalid: we can't complete that which we haven't started)
+    //
+    // WQ:        ----- 
+    // ZC:  -----
+    //
+    // Case 2: (invalid: we can't complete that which we haven't started)
+    //
+    // WQ:    -----
+    // ZC:  -----
+    //
+    // Case 3:
+    //
+    // WQ:  ----- 
+    // ZC:  -- 
+    //
+    // Case 4:
+    //
+    // WQ:  ----- 
+    // ZC:  ----- 
+    //
+    // Case 5:
+    //
+    // WQ:  ----- 
+    // ZC:     -- 
+    //
+    // Case 6: (invalid: we can't complete that which we haven't started)
+    //
+    // WQ:  ----- 
+    // ZC:    ----- 
+    //
+    // Case 7: (invalid: we can't complete that which we haven't started)
+    //
+    // WQ:  ----- 
+    // ZC:        ------
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_CONTEXT_GUARD_OWNER("test");
+
+    ntccfg::TestAllocator ta;
+    {
+        // clang-format off
+        struct Data {
+            bsl::size_t           d_line;
+            ntcq::ZeroCopyCounter d_lhsMin;
+            ntcq::ZeroCopyCounter d_lhsMax;
+            ntcq::ZeroCopyCounter d_rhsMin;
+            ntcq::ZeroCopyCounter d_rhsMax;
+            ntcq::ZeroCopyCounter d_intersectionMin;
+            ntcq::ZeroCopyCounter d_intersectionMax;
+            bsl::size_t           d_intersectionSize;
+        } DATA[] = {
+            { __LINE__, 0, 1,    0, 1,    0, 1, 1 },
+
+            { __LINE__, 3, 6,    0, 3,    0, 0,    0 }, // Case 1
+
+            { __LINE__, 3, 6,    0, 4,    3, 4,    1 }, // Case 2, size 1
+            { __LINE__, 3, 6,    0, 5,    3, 5,    2 }, // Case 2, size 2
+            { __LINE__, 3, 6,    0, 6,    3, 6,    3 }, // Case 2, size 3
+
+            { __LINE__, 3, 6,    3, 4,    3, 4,    1 }, // Case 3, size 1
+            { __LINE__, 3, 6,    3, 5,    3, 5,    2 }, // Case 3, size 2
+            { __LINE__, 3, 6,    3, 6,    3, 6,    3 }, // Case 3, size 3
+
+            { __LINE__, 3, 6,    3, 6,    3, 6,    3 }, // Case 4, size 3
+
+            { __LINE__, 3, 6,    3, 6,    3, 6,    3 }, // Case 5, size 3
+            { __LINE__, 3, 6,    4, 6,    4, 6,    2 }, // Case 5, size 2
+            { __LINE__, 3, 6,    5, 6,    5, 6,    1 }, // Case 5, size 1
+            
+            { __LINE__, 3, 6,    3, 6,    3, 6,    3 }, // Case 6, size 3
+            { __LINE__, 3, 6,    4, 6,    4, 6,    2 }, // Case 6, size 2
+            { __LINE__, 3, 6,    5, 8,    5, 6,    1 }, // Case 6, size 1
+            
+            { __LINE__, 3, 6,    6, 9,    0, 0,    0 }, // Case 7
+
+            { __LINE__, 0, 0,    0, 0,    0, 0, 0 }
+        };
+        // clang-format on
+
+        enum { NUM_DATA = sizeof(DATA) / sizeof(DATA[0]) };
+
+        for (bsl::size_t i = 0; i < NUM_DATA; ++i) {
+            const Data& data = DATA[i];
+
+            ntcq::ZeroCopyRange lhs(data.d_lhsMin, data.d_lhsMax);
+            ntcq::ZeroCopyRange rhs(data.d_rhsMin, data.d_rhsMax);
+
+            ntcq::ZeroCopyRange expectedIntersection(
+                data.d_intersectionMin, 
+                data.d_intersectionMax);
+
+            ntcq::ZeroCopyRange intersection = 
+                ntcq::ZeroCopyRange::intersect(lhs, rhs);
+
+            NTCI_LOG_STREAM_DEBUG 
+                << "Testing line " << data.d_line
+                << "\nL: " << lhs
+                << "\nR: " << rhs
+                << "\nE: " << expectedIntersection
+                << "\nF: " << intersection
+                << NTCI_LOG_STREAM_END;
+
+            if (expectedIntersection.empty()) {
+                NTCCFG_TEST_TRUE(intersection.empty());
+            }
+            else {
+                NTCCFG_TEST_EQ(intersection, expectedIntersection);
+            }
+        }
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(2)
 {
     // Concern:
     // Plan:
@@ -35,5 +154,6 @@ NTCCFG_TEST_CASE(1)
 NTCCFG_TEST_DRIVER
 {
     NTCCFG_TEST_REGISTER(1);
+    NTCCFG_TEST_REGISTER(2);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
@@ -478,6 +478,7 @@ NTCCFG_TEST_CASE(4)
         test::TransferHandle t0 = test::Transfer::create(s, 0, 1, dp, &ta);
 
         test::ZeroCopyUtil::submit(&zq, t0);
+        test::ZeroCopyUtil::invoke(&zq, s, false);
         test::ZeroCopyUtil::update(&zq, 0, 0);
         test::ZeroCopyUtil::invoke(&zq, s, true);
 
@@ -508,6 +509,8 @@ NTCCFG_TEST_CASE(5)
         
         test::ZeroCopyUtil::submit(&zq, t0);
         test::ZeroCopyUtil::submit(&zq, t1);
+
+        test::ZeroCopyUtil::invoke(&zq, s, false);
 
         test::ZeroCopyUtil::update(&zq, 0, 0);
         test::ZeroCopyUtil::invoke(&zq, s, true);
@@ -548,6 +551,8 @@ NTCCFG_TEST_CASE(6)
         test::ZeroCopyUtil::submit(&zq, t0);
         test::ZeroCopyUtil::submit(&zq, t1);
         test::ZeroCopyUtil::submit(&zq, t2);
+
+        test::ZeroCopyUtil::invoke(&zq, s, false);
 
         test::ZeroCopyUtil::update(&zq, 0, 0);
         test::ZeroCopyUtil::invoke(&zq, s, true);
@@ -626,6 +631,13 @@ NTCCFG_TEST_CASE(7)
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
+
+
+
+
+
+
+
 
 NTCCFG_TEST_CASE(8)
 {

--- a/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
@@ -14,17 +14,19 @@
 // limitations under the License.
 
 #include <ntcq_zerocopy.h>
+
+#include <ntcq_send.h>
+#include <ntci_sender.h>
+#include <ntci_sendcallback.h>
 #include <ntcs_datapool.h>
-
 #include <ntccfg_test.h>
-
 #include <bslma_allocator.h>
 
 using namespace BloombergLP;
 
 NTCCFG_TEST_CASE(1)
 {
-    // Concern:
+    // Concern: Test ntcq::ZeroCopyRange::intersection()
     // Plan:
 
     // Case 1: (invalid: we can't complete that which we haven't started)
@@ -147,11 +149,303 @@ NTCCFG_TEST_CASE(1)
 
 NTCCFG_TEST_CASE(2)
 {
-    // Concern:
+    // Concern: Test ntcq::ZeroCopyRange::difference()
     // Plan:
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_CONTEXT_GUARD_OWNER("test");
 
     ntccfg::TestAllocator ta;
     {
+        // LHS:     ----- 
+        // RHS: --------------
+
+        {
+            ntcq::ZeroCopyRange lhs(3, 6);
+            ntcq::ZeroCopyRange rhs(0, 9);
+
+            ntcq::ZeroCopyRange result;
+            ntcq::ZeroCopyRange overflow;
+
+            ntcq::ZeroCopyRange::difference(&result, &overflow, lhs, rhs);
+
+            NTCCFG_TEST_TRUE(result.empty());
+            NTCCFG_TEST_TRUE(overflow.empty());
+        }
+
+        // LHS: RRR----
+        // RHS:    ----
+
+        {
+            ntcq::ZeroCopyRange lhs(0, 6);
+            ntcq::ZeroCopyRange rhs(3, 6);
+
+            ntcq::ZeroCopyRange result;
+            ntcq::ZeroCopyRange overflow;
+
+            ntcq::ZeroCopyRange::difference(&result, &overflow, lhs, rhs);
+
+            NTCCFG_TEST_EQ(result.minCounter(), 0);
+            NTCCFG_TEST_EQ(result.maxCounter(), 3);
+
+            NTCCFG_TEST_TRUE(overflow.empty());
+        }
+
+        // LHS: ----OOO
+        // RHS: ----
+
+        {
+            ntcq::ZeroCopyRange lhs(3, 9);
+            ntcq::ZeroCopyRange rhs(3, 6);
+
+            ntcq::ZeroCopyRange result;
+            ntcq::ZeroCopyRange overflow;
+
+            ntcq::ZeroCopyRange::difference(&result, &overflow, lhs, rhs);
+
+            NTCCFG_TEST_EQ(result.minCounter(), 6);
+            NTCCFG_TEST_EQ(result.maxCounter(), 9);
+
+            NTCCFG_TEST_TRUE(overflow.empty());
+        }
+
+        // LHS: RRR----OOO
+        // RHS:    ----
+
+        {
+            ntcq::ZeroCopyRange lhs(0, 9);
+            ntcq::ZeroCopyRange rhs(3, 6);
+
+            ntcq::ZeroCopyRange result;
+            ntcq::ZeroCopyRange overflow;
+
+            ntcq::ZeroCopyRange::difference(&result, &overflow, lhs, rhs);
+
+            NTCCFG_TEST_EQ(result.minCounter(), 0);
+            NTCCFG_TEST_EQ(result.maxCounter(), 3);
+
+            NTCCFG_TEST_EQ(overflow.minCounter(), 6);
+            NTCCFG_TEST_EQ(overflow.maxCounter(), 9);
+        }
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(3)
+{
+    // Concern: Test 32-bit ntsa::ZeroCopy counter wraparound
+    // Plan:
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_CONTEXT_GUARD_OWNER("test");
+
+    ntccfg::TestAllocator ta;
+    {
+        // TODO
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+namespace test {
+
+/// Provide a mechanism to track the transfer state of data that is 
+/// zero-copied.
+class Transfer {
+    ntcq::SendCounter                d_group;
+    bsl::size_t                      d_numRequired;
+    bsl::size_t                      d_numComplete;
+    bsl::shared_ptr<ntci::Sender>    d_sender_sp;
+    bsl::shared_ptr<ntsa::Data>      d_data_sp;
+    bsl::shared_ptr<ntci::DataPool>  d_dataPool_sp;
+    bslma::Allocator                *d_allocator_p;
+
+private:
+    Transfer(const Transfer&) BSLS_KEYWORD_DELETED;
+    Transfer& operator=(const Transfer&) BSLS_KEYWORD_DELETED;
+
+private:
+    /// Process the completion of a zero-copy transmission by the specified
+    /// 'sender' according to the specified 'event'.
+    void processComplete(const bsl::shared_ptr<ntci::Sender>& sender,
+                         const ntca::SendEvent&               event);
+
+public:
+    /// Create a new transfer for the specified 'group' requiring the specified
+    /// 'numOperations' to transfer all the data provided by the specified
+    /// 'dataPool'. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    Transfer(const bsl::shared_ptr<ntci::Sender>&   sender,
+             ntcq::SendCounter                      group, 
+             bsl::size_t                            numOperations,
+             const bsl::shared_ptr<ntci::DataPool>& dataPool,
+             bslma::Allocator*                      basicAllocator = 0);
+
+    /// Destroy this object.
+    ~Transfer();
+
+    /// Initiate this transfer to the specified 'zeroCopyQueue'. 
+    void initiate(ntcq::ZeroCopyQueue* zeroCopyQueue);
+
+    /// Return the identifier of the transfer.
+    ntcq::SendCounter group() const;
+
+    /// Return true if all required operations for this transfer have been
+    /// completed, otherwise return false. 
+    bool complete() const;
+
+    /// Return a new transfer for the specified 'group' requiring the specified
+    /// 'numOperations' to transfer all the data provided by the specified
+    /// 'dataPool'. Optionally specify a 'basicAllocator' used to supply
+    /// memory. If 'basicAllocator' is 0, the currently installed default
+    /// allocator is used.
+    static bsl::shared_ptr<Transfer> create(
+        const bsl::shared_ptr<ntci::Sender>&   sender,
+        ntcq::SendCounter                      group, 
+        bsl::size_t                            numOperations,
+        const bsl::shared_ptr<ntci::DataPool>& dataPool,
+        bslma::Allocator*                      basicAllocator = 0);
+};
+
+void Transfer::processComplete(const bsl::shared_ptr<ntci::Sender>& sender,
+                               const ntca::SendEvent&               event)
+{
+    NTCCFG_TEST_EQ(sender, d_sender_sp);
+    NTCCFG_TEST_EQ(event.type(), ntca::SendEventType::e_COMPLETE);
+    NTCCFG_TEST_LT(d_numComplete, d_numRequired);
+
+    ++d_numComplete;
+}
+
+Transfer::Transfer(const bsl::shared_ptr<ntci::Sender>&   sender,
+                   ntcq::SendCounter                      group, 
+                   bsl::size_t                            numOperations,
+                   const bsl::shared_ptr<ntci::DataPool>& dataPool,
+                   bslma::Allocator*                      basicAllocator)
+: d_group(group)
+, d_numRequired(numOperations)
+, d_numComplete(0)
+, d_sender_sp(sender)
+, d_data_sp(dataPool->createOutgoingData())
+, d_dataPool_sp(dataPool)
+, d_allocator_p(bslma::Default::allocator(basicAllocator))
+{
+}
+
+Transfer::~Transfer()
+{
+}
+
+void Transfer::initiate(ntcq::ZeroCopyQueue* zeroCopyQueue)
+{
+    NTCCFG_TEST_GT(d_numRequired, 0);
+    NTCCFG_TEST_EQ(d_numComplete, 0);
+
+    ntci::SendCallback callback(
+        NTCCFG_BIND(&Transfer::processComplete, 
+                    this, 
+                    NTCCFG_BIND_PLACEHOLDER_1, 
+                    NTCCFG_BIND_PLACEHOLDER_2));
+
+    for (bsl::size_t i = 0; i < d_numRequired; ++i) {
+        if (i == 0) {
+            zeroCopyQueue->push(d_group, d_data_sp, callback);
+        }
+        else {
+            zeroCopyQueue->push(d_group);
+        }
+    }
+
+    zeroCopyQueue->frame(d_group);
+}
+
+ntcq::SendCounter Transfer::group() const
+{
+    return d_group;
+}
+
+bool Transfer::complete() const
+{
+    return d_numComplete == d_numRequired;
+}
+
+bsl::shared_ptr<Transfer> Transfer::create(
+    const bsl::shared_ptr<ntci::Sender>&   sender,
+    ntcq::SendCounter                      group, 
+    bsl::size_t                            numOperations,
+    const bsl::shared_ptr<ntci::DataPool>& dataPool,
+    bslma::Allocator*                      basicAllocator)
+{
+    bslma::Allocator* allocator = bslma::Default::allocator(basicAllocator);
+
+    bsl::shared_ptr<Transfer> transfer;
+    transfer.createInplace(
+        allocator, sender, group, numOperations, dataPool, allocator);
+
+    return transfer;
+}
+
+} // close namespace test
+
+NTCCFG_TEST_CASE(4)
+{
+    // Concern: Test ntcq::ZeroCopyQueue sanity check
+    // Plan:
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_CONTEXT_GUARD_OWNER("test");
+
+    ntccfg::TestAllocator ta;
+    {
+        bsl::shared_ptr<ntci::Sender> sender;
+
+        bsl::shared_ptr<ntci::Strand> strand = ntci::Strand::unknown();
+
+        bsl::shared_ptr<ntcs::DataPool> dataPool;
+        dataPool.createInplace(&ta, &ta);
+
+        ntcq::ZeroCopyQueue zeroCopyQueue(dataPool, &ta);
+
+        bsl::shared_ptr<test::Transfer> transfer = test::Transfer::create(
+            sender, 0, 1, dataPool, &ta);
+
+        transfer->initiate(&zeroCopyQueue);
+
+        ntsa::ZeroCopy zeroCopy(0, 0, 1);
+        zeroCopyQueue.update(zeroCopy);
+
+        ntci::SendCallback callback;
+        bool exists = zeroCopyQueue.pop(&callback);
+
+        NTCCFG_TEST_TRUE(exists);
+        NTCCFG_TEST_TRUE(callback);
+
+        ntca::SendEvent event;
+        event.setType(ntca::SendEventType::e_COMPLETE);
+
+        callback(sender, event, strand);
+
+        NTCCFG_TEST_TRUE(transfer->complete());
+    }
+    NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
+}
+
+NTCCFG_TEST_CASE(5)
+{
+    // Concern: Test ntcq::ZeroCopyQueue exhaustive test
+    // Plan:
+
+    NTCI_LOG_CONTEXT();
+    NTCI_LOG_CONTEXT_GUARD_OWNER("test");
+
+    ntccfg::TestAllocator ta;
+    {
+        bsl::shared_ptr<ntcs::DataPool> dataPool;
+        dataPool.createInplace(&ta, &ta);
+
+        ntcq::ZeroCopyQueue zeroCopyQueue(dataPool, &ta);
+
+
     }
     NTCCFG_TEST_ASSERT(ta.numBlocksInUse() == 0);
 }
@@ -160,5 +454,8 @@ NTCCFG_TEST_DRIVER
 {
     NTCCFG_TEST_REGISTER(1);
     NTCCFG_TEST_REGISTER(2);
+    NTCCFG_TEST_REGISTER(3);
+    NTCCFG_TEST_REGISTER(4);
+    NTCCFG_TEST_REGISTER(5);
 }
 NTCCFG_TEST_DRIVER_END;

--- a/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
+++ b/groups/ntc/ntcq/ntcq_zerocopy.t.cpp
@@ -34,13 +34,13 @@ NTCCFG_TEST_CASE(1)
     //
     // Case 2: (invalid: we can't complete that which we haven't started)
     //
-    // WQ:    -----
-    // ZC:  -----
+    // WQ:    XXX--
+    // ZC:  --XXX
     //
     // Case 3:
     //
-    // WQ:  ----- 
-    // ZC:  -- 
+    // WQ:  XX--- 
+    // ZC:  XX 
     //
     // Case 4:
     //
@@ -49,18 +49,23 @@ NTCCFG_TEST_CASE(1)
     //
     // Case 5:
     //
-    // WQ:  ----- 
-    // ZC:     -- 
+    // WQ:  ---XX 
+    // ZC:     XX 
     //
     // Case 6: (invalid: we can't complete that which we haven't started)
     //
-    // WQ:  ----- 
-    // ZC:    ----- 
+    // WQ:  --XXX 
+    // ZC:    XXX-- 
     //
     // Case 7: (invalid: we can't complete that which we haven't started)
     //
     // WQ:  ----- 
     // ZC:        ------
+
+    // Case 8: split
+    //
+    // WQ:  ---------- 
+    // ZC:    ------
 
     NTCI_LOG_CONTEXT();
     NTCI_LOG_CONTEXT_GUARD_OWNER("test");

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -1832,17 +1832,16 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
 
     ntsa::SendOptions options;
 
-    if (!endpoint.isNull()) {
-        if (endpoint.value() != d_remoteEndpoint) {
+    if (d_remoteEndpoint.isUndefined()) {
+        if (!endpoint.isNull()) {
+            options.setEndpoint(endpoint.value());
+        }
+        else {
             return ntsa::Error(ntsa::Error::e_INVALID);
         }
-
-        options.setEndpoint(endpoint.value());
     }
-    else {
-        if (d_remoteEndpoint.isUndefined()) {
-            return ntsa::Error(ntsa::Error::e_INVALID);
-        }
+    else if (!endpoint.isNull() && endpoint.value() != d_remoteEndpoint) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
     if (static_cast<bsl::size_t>(data.length()) >= d_zeroCopyThreshold) {

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -2265,10 +2265,7 @@ ntsa::Error DatagramSocket::privateOpen(
             option.makeZeroCopy(true);
             error = datagramSocket->setOption(option);
             if (error) {
-                NTCI_LOG_WARN("ZeroCopy was requested but the OS refused to "
-                              "enable it, continue in normal mode");
-                d_options.zeroCopyThreshold() =
-                    bdlb::NullableValue<bsl::size_t>();
+                NTCI_LOG_DEBUG("Zero-copy was requested but not supported");
                 d_zeroCopyThreshold = bsl::numeric_limits<bsl::size_t>::max();
             }
             else {

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -1144,7 +1144,7 @@ void DatagramSocket::privateShutdownSequence(
     bool asyncDetachmentStarted = false;
     if (context.shutdownCompleted()) {
         ntci::SocketDetachedCallback detachCallback(
-            NTCCFG_BIND(&DatagramSocket::privateShutdownSequencePart2,
+            NTCCFG_BIND(&DatagramSocket::privateShutdownSequenceComplete,
                         this,
                         self,
                         context,
@@ -1175,11 +1175,11 @@ void DatagramSocket::privateShutdownSequence(
     }
 
     if (!asyncDetachmentStarted) {
-        this->privateShutdownSequencePart2(self, context, defer, false);
+        this->privateShutdownSequenceComplete(self, context, defer, false);
     }
 }
 
-void DatagramSocket::privateShutdownSequencePart2(
+void DatagramSocket::privateShutdownSequenceComplete(
     const bsl::shared_ptr<DatagramSocket>& self,
     const ntcs::ShutdownContext&           context,
     bool                                   defer,

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -118,8 +118,14 @@ BSLS_IDENT_RCSID(ntcr_datagramsocket_cpp, "$Id$ $CSID$")
     NTCI_LOG_TRACE("Datagram socket "                                         \
                    "has saturated the number of pinned pages")
 
+#define NTCR_DATAGRAMSOCKET_LOG_ZERO_COPY_UPDATE(zeroCopy)                    \
+    NTCI_LOG_TRACE("Datagram socket zero copy %s [ %u, %u ]", \
+                  ntsa::ZeroCopyType::toString((zeroCopy).type()), \
+                  (zeroCopy).from(), \
+                  (zeroCopy).thru())
+
 #define NTCR_DATAGRAMSOCKET_LOG_ZERO_COPY_DISABLED()                          \
-    NTCI_LOG_WARN("Zero copy is disabled due to ENOBUFS")
+    NTCI_LOG_DEBUG("Datagram socket zero copy is disabled")
 
 #define NTCR_DATAGRAMSOCKET_LOG_SEND_RESULT(context)                          \
     NTCI_LOG_TRACE("Datagram socket "                                         \
@@ -542,6 +548,15 @@ void DatagramSocket::privateZeroCopyUpdate(
         const bsl::shared_ptr<DatagramSocket>& self,
         const ntsa::ZeroCopy&                  zeroCopy)
 {
+    NTCI_LOG_CONTEXT();
+
+    NTCR_DATAGRAMSOCKET_LOG_ZERO_COPY_UPDATE(zeroCopy);
+
+    if (zeroCopy.type() != ntsa::ZeroCopyType::e_AVOIDED) {
+        NTCR_DATAGRAMSOCKET_LOG_ZERO_COPY_DISABLED();
+        d_zeroCopyThreshold = k_ZERO_COPY_NEVER;
+    }
+
     d_zeroCopyQueue.update(zeroCopy);
 
     if (d_zeroCopyQueue.ready()) {

--- a/groups/ntc/ntcr/ntcr_datagramsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.cpp
@@ -1938,17 +1938,16 @@ ntsa::Error DatagramSocket::privateEnqueueSendBuffer(
 
     ntsa::SendOptions options;
 
-    if (!endpoint.isNull()) {
-        if (endpoint.value() != d_remoteEndpoint) {
+    if (d_remoteEndpoint.isUndefined()) {
+        if (!endpoint.isNull()) {
+            options.setEndpoint(endpoint.value());
+        }
+        else {
             return ntsa::Error(ntsa::Error::e_INVALID);
         }
-
-        options.setEndpoint(endpoint.value());
     }
-    else {
-        if (d_remoteEndpoint.isUndefined()) {
-            return ntsa::Error(ntsa::Error::e_INVALID);
-        }
+    else if (!endpoint.isNull() && endpoint.value() != d_remoteEndpoint) {
+        return ntsa::Error(ntsa::Error::e_INVALID);
     }
 
     if (data.size() >= d_zeroCopyThreshold) {

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -95,26 +95,30 @@ class DatagramSocket : public ntci::DatagramSocket,
     bsl::shared_ptr<ntcs::Metrics>               d_metrics_sp;
     ntcs::FlowControlState                       d_flowControlState;
     ntcs::ShutdownState                          d_shutdownState;
-    ntcq::SendQueue                              d_sendQueue;
     ntcq::ZeroCopyWaitList                       d_zeroCopyList;
     bsl::size_t                                  d_zeroCopyThreshold;
+    ntcq::SendQueue                              d_sendQueue;
     bsl::shared_ptr<ntci::RateLimiter>           d_sendRateLimiter_sp;
     bsl::shared_ptr<ntci::Timer>                 d_sendRateTimer_sp;
     bool                                         d_sendGreedily;
+    ntsa::ReceiveOptions                         d_receiveOptions;
     ntcq::ReceiveQueue                           d_receiveQueue;
     bsl::shared_ptr<ntci::RateLimiter>           d_receiveRateLimiter_sp;
     bsl::shared_ptr<ntci::Timer>                 d_receiveRateTimer_sp;
     bool                                         d_receiveGreedily;
     bsl::shared_ptr<bdlbb::Blob>                 d_receiveBlob_sp;
+    bool                                         d_timestampOutgoingData;
+    bool                                         d_timestampIncomingData;
+    ntcu::TimestampCorrelator                    d_timestampCorrelator;
+    bsl::uint32_t                                d_timestampCounter;
     bsl::size_t                                  d_maxDatagramSize;
     const bool                                   d_oneShot;
-    bool                                         d_timestampOutgoingData;
-    ntca::DatagramSocketOptions                  d_options;
-    ntcu::TimestampCorrelator                    d_timestampCorrelator;
-    bsl::uint32_t                                d_dgramTsIdCounter;
     ntcs::DetachState                            d_detachState;
     ntci::CloseCallback                          d_closeCallback;
     ntci::Executor::FunctorSequence              d_deferredCalls;
+    bsl::size_t                                  d_totalBytesSent;
+    bsl::size_t                                  d_totalBytesReceived;
+    ntca::DatagramSocketOptions                  d_options;
     bslma::Allocator*                            d_allocator_p;
 
   private:
@@ -854,6 +858,10 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// Return the error.
     ntsa::Error deregisterSession() BSLS_KEYWORD_OVERRIDE;
 
+    /// Set the minimum number of bytes that must be available to send in order
+    /// to attempt a zero-copy send to the specified 'value'. Return the error.
+    ntsa::Error setZeroCopyThreshold(bsl::size_t value) BSLS_KEYWORD_OVERRIDE;
+
     /// Set the write rate limiter to the specified 'rateLimiter'. Return
     /// the error.
     ntsa::Error setWriteRateLimiter(const bsl::shared_ptr<ntci::RateLimiter>&
@@ -930,6 +938,11 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// successful (though it does not guarantee that transmit timestamps would
     /// be generated). Otherwise return false.
     ntsa::Error timestampOutgoingData(bool enable) BSLS_KEYWORD_OVERRIDE;
+
+    /// Request the implementation to start timestamping incoming data if the
+    /// specified 'enable' flag is true. Otherwise, request the implementation
+    /// to stop timestamping outgoing data. Return the error.
+    ntsa::Error timestampIncomingData(bool enable) BSLS_KEYWORD_OVERRIDE;
 
     /// Enable copying from the socket buffers in the specified 'direction'.
     ntsa::Error relaxFlowControl(ntca::FlowControlType::Value direction)

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -101,6 +101,7 @@ class DatagramSocket : public ntci::DatagramSocket,
     bsl::shared_ptr<ntci::RateLimiter>           d_sendRateLimiter_sp;
     bsl::shared_ptr<ntci::Timer>                 d_sendRateTimer_sp;
     bool                                         d_sendGreedily;
+    ntci::SendCallback                           d_sendComplete;
     ntsa::ReceiveOptions                         d_receiveOptions;
     ntcq::ReceiveQueue                           d_receiveQueue;
     bsl::shared_ptr<ntci::RateLimiter>           d_receiveRateLimiter_sp;

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -374,6 +374,12 @@ class DatagramSocket : public ntci::DatagramSocket,
         const bsl::shared_ptr<DatagramSocket>& self,
         bool                                   enable);
 
+    /// Enable or disable timestamping of incoming data according to the 
+    /// specified 'enable' flag. Return the error.
+    ntsa::Error privateTimestampIncomingData(
+        const bsl::shared_ptr<DatagramSocket>& self,
+        bool                                   enable);
+
     /// Process the detection of the specified outgoing data 'timestamp'.
     void privateTimestampUpdate(
             const bsl::shared_ptr<DatagramSocket>& self,

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -283,6 +283,7 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// undefined unless 'd_mutex' is locked.
     ntsa::Error privateEnqueueSendBuffer(
         const bsl::shared_ptr<DatagramSocket>&     self,
+        ntsa::SendContext*                         context,
         const bdlb::NullableValue<ntsa::Endpoint>& endpoint,
         const bdlbb::Blob&                         data);
 
@@ -291,6 +292,7 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// undefined unless 'd_mutex' is locked.
     ntsa::Error privateEnqueueSendBuffer(
         const bsl::shared_ptr<DatagramSocket>&     self,
+        ntsa::SendContext*                         context,
         const bdlb::NullableValue<ntsa::Endpoint>& endpoint,
         const ntsa::Data&                          data);
 

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -95,13 +95,14 @@ class DatagramSocket : public ntci::DatagramSocket,
     bsl::shared_ptr<ntcs::Metrics>               d_metrics_sp;
     ntcs::FlowControlState                       d_flowControlState;
     ntcs::ShutdownState                          d_shutdownState;
-    ntcq::ZeroCopyWaitList                       d_zeroCopyList;
+    ntcq::ZeroCopyQueue                          d_zeroCopyQueue;
     bsl::size_t                                  d_zeroCopyThreshold;
     ntcq::SendQueue                              d_sendQueue;
     bsl::shared_ptr<ntci::RateLimiter>           d_sendRateLimiter_sp;
     bsl::shared_ptr<ntci::Timer>                 d_sendRateTimer_sp;
     bool                                         d_sendGreedily;
     ntci::SendCallback                           d_sendComplete;
+    ntcq::SendCounter                            d_sendCounter;
     ntsa::ReceiveOptions                         d_receiveOptions;
     ntcq::ReceiveQueue                           d_receiveQueue;
     bsl::shared_ptr<ntci::RateLimiter>           d_receiveRateLimiter_sp;

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -229,7 +229,7 @@ class DatagramSocket : public ntci::DatagramSocket,
 
     /// Execute the second part of shutdown sequence when the socket is
     /// detached. See also "privateShutdownSequence".
-    void privateShutdownSequencePart2(
+    void privateShutdownSequenceComplete(
         const bsl::shared_ptr<DatagramSocket>& self,
         const ntcs::ShutdownContext&           context,
         bool                                   defer,

--- a/groups/ntc/ntcr/ntcr_datagramsocket.h
+++ b/groups/ntc/ntcr/ntcr_datagramsocket.h
@@ -364,21 +364,22 @@ class DatagramSocket : public ntci::DatagramSocket,
         const ntca::ConnectOptions&            connectOptions,
         const ntci::ConnectCallback&           connectCallback);
 
-    /// Start timestamping outgoing data. Prepare buffers and request the OS to
-    /// enable transmit timestamps. Return no error in case of success,
-    /// return error otherwise.
-    ntsa::Error startTimestampOutgoingData();
+    /// Enable or disable timestamping of outgoing data according to the 
+    /// specified 'enable' flag. Return the error.
+    ntsa::Error privateTimestampOutgoingData(
+        const bsl::shared_ptr<DatagramSocket>& self,
+        bool                                   enable);
 
-    /// Stop timestamping outgoing data. Return no error in case of success,
-    /// return error otherwise.
-    ntsa::Error stopTimestampOutgoingData();
+    /// Process the detection of the specified outgoing data 'timestamp'.
+    void privateTimestampUpdate(
+            const bsl::shared_ptr<DatagramSocket>& self,
+            const ntsa::Timestamp&                 timestamp);
 
-    /// Request the OS to enable transmit timestamps if the specified 'enable'
-    /// is true. Return true in case of success. Return false otherwise.
-    ntsa::Error privateTimestampOutgoingData(bool enable);
-
-    /// Process notification containing the specified 'timestamp'.
-    void processTimestampNotification(const ntsa::Timestamp& timestamp);
+    // Process the completion of one or more zero-copy tranmsissions described
+    // by the specified 'zeroCopy' notification.
+    void privateZeroCopyUpdate(
+            const bsl::shared_ptr<DatagramSocket>& self,
+            const ntsa::ZeroCopy&                  zeroCopy);
 
   public:
     /// Create a new, initially uninitilialized datagram socket. Optionally
@@ -923,6 +924,13 @@ class DatagramSocket : public ntci::DatagramSocket,
                                     const ntsa::IpAddress& group)
         BSLS_KEYWORD_OVERRIDE;
 
+    /// Request the implementation to start timestamping outgoing data if the
+    /// specified 'enable' flag is true. Otherwise, request the implementation
+    /// to stop timestamping outgoing data. Return true if operation was
+    /// successful (though it does not guarantee that transmit timestamps would
+    /// be generated). Otherwise return false.
+    ntsa::Error timestampOutgoingData(bool enable) BSLS_KEYWORD_OVERRIDE;
+
     /// Enable copying from the socket buffers in the specified 'direction'.
     ntsa::Error relaxFlowControl(ntca::FlowControlType::Value direction)
         BSLS_KEYWORD_OVERRIDE;
@@ -970,13 +978,6 @@ class DatagramSocket : public ntci::DatagramSocket,
     /// invoked on this object's strand unless an explicit strand is
     /// specified at the time the callback is created.
     void close(const ntci::CloseCallback& callback) BSLS_KEYWORD_OVERRIDE;
-
-    /// Request the implementation to start timestamping outgoing data if the
-    /// specified 'enable' flag is true. Otherwise, request the implementation
-    /// to stop timestamping outgoing data. Return true if operation was
-    /// successful (though it does not guarantee that transmit timestamps would
-    /// be generated). Otherwise return false.
-    ntsa::Error timestampOutgoingData(bool enable) BSLS_KEYWORD_OVERRIDE;
 
     /// Defer the execution of the specified 'functor'.
     void execute(const Functor& functor) BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcr/ntcr_listenersocket.cpp
+++ b/groups/ntc/ntcr/ntcr_listenersocket.cpp
@@ -595,7 +595,7 @@ void ListenerSocket::privateShutdownSequence(
     bool asyncDetachmentStarted = false;
     if (context.shutdownCompleted()) {
         ntci::SocketDetachedCallback detachCallback(
-            NTCCFG_BIND(&ListenerSocket::privateShutdownSequencePart2,
+            NTCCFG_BIND(&ListenerSocket::privateShutdownSequenceComplete,
                         this,
                         self,
                         context,
@@ -626,11 +626,11 @@ void ListenerSocket::privateShutdownSequence(
     }
 
     if (!asyncDetachmentStarted) {
-        privateShutdownSequencePart2(self, context, defer, false);
+        privateShutdownSequenceComplete(self, context, defer, false);
     }
 }
 
-void ListenerSocket::privateShutdownSequencePart2(
+void ListenerSocket::privateShutdownSequenceComplete(
     const bsl::shared_ptr<ListenerSocket>& self,
     const ntcs::ShutdownContext&           context,
     bool                                   defer,
@@ -649,7 +649,7 @@ void ListenerSocket::privateShutdownSequencePart2(
                     ntcs::DetachState::e_DETACH_INITIATED);
     }
 
-    // Second handle socket shutdown.
+    // Second, handle socket shutdown.
 
     if (context.shutdownSend()) {
         if (d_socket_sp) {
@@ -663,7 +663,7 @@ void ListenerSocket::privateShutdownSequencePart2(
         }
     }
 
-    // Third handle internal data structures and announce events.
+    // Third, handle internal data structures and announce events.
 
     if (context.shutdownInitiated()) {
         if (d_session_sp) {

--- a/groups/ntc/ntcr/ntcr_listenersocket.h
+++ b/groups/ntc/ntcr/ntcr_listenersocket.h
@@ -190,7 +190,7 @@ class ListenerSocket : public ntci::ListenerSocket,
 
     /// Execute the second part of shutdown sequence when the socket is
     /// detached. See also "privateShutdownSequence".
-    void privateShutdownSequencePart2(
+    void privateShutdownSequenceComplete(
         const bsl::shared_ptr<ListenerSocket>& self,
         const ntcs::ShutdownContext&           context,
         bool                                   defer,

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -165,8 +165,14 @@ BSLS_IDENT_RCSID(ntcr_streamsocket_cpp, "$Id$ $CSID$")
     NTCI_LOG_TRACE("Stream socket "                                           \
                    "has saturated the number of pinned pages")
 
+#define NTCR_STREAMSOCKET_LOG_ZERO_COPY_UPDATE(zeroCopy)                      \
+    NTCI_LOG_TRACE("Stream socket zero copy %s [ %u, %u ]", \
+                  ntsa::ZeroCopyType::toString((zeroCopy).type()), \
+                  (zeroCopy).from(), \
+                  (zeroCopy).thru())
+
 #define NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED()                            \
-    NTCI_LOG_WARN("Zero copy is disabled due to ENOBUFS")
+    NTCI_LOG_DEBUG("Stream socket zero copy is disabled")
 
 #define NTCR_STREAMSOCKET_LOG_SEND_RESULT(context)                            \
     NTCI_LOG_TRACE("Stream socket "                                           \
@@ -4299,6 +4305,15 @@ void StreamSocket::privateZeroCopyUpdate(
             const bsl::shared_ptr<StreamSocket>& self,
             const ntsa::ZeroCopy&                zeroCopy)
 {
+    NTCI_LOG_CONTEXT();
+
+    NTCR_STREAMSOCKET_LOG_ZERO_COPY_UPDATE(zeroCopy);
+
+    if (zeroCopy.type() != ntsa::ZeroCopyType::e_AVOIDED) {
+        NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED();
+        d_zeroCopyThreshold = k_ZERO_COPY_NEVER;
+    }
+
     d_zeroCopyQueue.update(zeroCopy);
 
     if (d_zeroCopyQueue.ready()) {

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -474,7 +474,7 @@ void StreamSocket::processNotifications(
     NTCI_LOG_CONTEXT_GUARD_DESCRIPTOR(d_publicHandle);
     NTCI_LOG_CONTEXT_GUARD_SOURCE_ENDPOINT(d_sourceEndpoint);
 
-    typedef bsl::vector<ntsa::Notification>::const_iterator 
+    typedef bsl::vector<ntsa::Notification>::const_iterator
     NotificationIterator;
 
     NotificationIterator it = notifications.notifications().begin();
@@ -1225,14 +1225,14 @@ ntsa::Error StreamSocket::privateSocketWritableIterationBatch(
 
         if (context.zeroCopy()) {
             if (entry.zeroCopy()) {
-                ntcq::ZeroCopyCounter zeroCopyCounter = 
+                ntcq::ZeroCopyCounter zeroCopyCounter =
                     d_zeroCopyQueue.push(entry.id());
 
                 NTCCFG_WARNING_UNUSED(zeroCopyCounter);
                 NTCR_STREAMSOCKET_LOG_ZERO_COPY_STARTING(zeroCopyCounter);
             }
             else {
-                ntcq::ZeroCopyCounter zeroCopyCounter = 
+                ntcq::ZeroCopyCounter zeroCopyCounter =
                     d_zeroCopyQueue.push(
                         entry.id(), entry.data(), entry.callback());
 
@@ -1354,14 +1354,14 @@ ntsa::Error StreamSocket::privateSocketWritableIterationFront(
 
         if (context.zeroCopy()) {
             if (entry.zeroCopy()) {
-                ntcq::ZeroCopyCounter zeroCopyCounter = 
+                ntcq::ZeroCopyCounter zeroCopyCounter =
                     d_zeroCopyQueue.push(entry.id());
 
                 NTCCFG_WARNING_UNUSED(zeroCopyCounter);
                 NTCR_STREAMSOCKET_LOG_ZERO_COPY_STARTING(zeroCopyCounter);
             }
             else {
-                ntcq::ZeroCopyCounter zeroCopyCounter = 
+                ntcq::ZeroCopyCounter zeroCopyCounter =
                     d_zeroCopyQueue.push(
                         entry.id(), entry.data(), entry.callback());
 
@@ -2730,8 +2730,8 @@ ntsa::Error StreamSocket::privateEnqueueSendBuffer(
         }
     }
 
-    if (options.zeroCopy() != context->zeroCopy() && 
-        d_zeroCopyThreshold != k_ZERO_COPY_NEVER) 
+    if (options.zeroCopy() != context->zeroCopy() &&
+        d_zeroCopyThreshold != k_ZERO_COPY_NEVER)
     {
         NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED();
         d_zeroCopyThreshold = k_ZERO_COPY_NEVER;
@@ -2782,7 +2782,7 @@ ntsa::Error StreamSocket::privateEnqueueSendBuffer(
     }
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if ((d_sendCounter % NTCR_STREAMSOCKET_SEND_BUFFER_REFRESH_INTERVAL) == 0) 
+    if ((d_sendCounter % NTCR_STREAMSOCKET_SEND_BUFFER_REFRESH_INTERVAL) == 0)
     {
         if (data.size() >=
             NTCR_STREAMSOCKET_SEND_BUFFER_REFRESH_SIZE_THRESHOLD)
@@ -2830,8 +2830,8 @@ ntsa::Error StreamSocket::privateEnqueueSendBuffer(
         }
     }
 
-    if (options.zeroCopy() != context->zeroCopy() && 
-        d_zeroCopyThreshold != k_ZERO_COPY_NEVER) 
+    if (options.zeroCopy() != context->zeroCopy() &&
+        d_zeroCopyThreshold != k_ZERO_COPY_NEVER)
     {
         NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED();
         d_zeroCopyThreshold = k_ZERO_COPY_NEVER;
@@ -3188,7 +3188,7 @@ ntsa::Error StreamSocket::privateSendRaw(
 
     if (context.bytesSent() == static_cast<bsl::size_t>(data.length())) {
         if (context.zeroCopy()) {
-            ntcq::ZeroCopyCounter zeroCopyCounter = 
+            ntcq::ZeroCopyCounter zeroCopyCounter =
                 d_zeroCopyQueue.push(state.counter(), data, callback);
 
             NTCCFG_WARNING_UNUSED(zeroCopyCounter);
@@ -3224,7 +3224,7 @@ ntsa::Error StreamSocket::privateSendRaw(
     BSLS_ASSERT(dataContainer->blob().length() != 0);
 
     if (context.zeroCopy()) {
-        ntcq::ZeroCopyCounter zeroCopyCounter = 
+        ntcq::ZeroCopyCounter zeroCopyCounter =
             d_zeroCopyQueue.push(state.counter(), dataContainer, callback);
 
         NTCCFG_WARNING_UNUSED(zeroCopyCounter);
@@ -3307,12 +3307,12 @@ ntsa::Error StreamSocket::privateSendRaw(
         }
     }
 
-    BSLS_ASSERT((!error && context.bytesSent() > 0) || 
+    BSLS_ASSERT((!error && context.bytesSent() > 0) ||
                  (error == ntsa::Error::e_WOULD_BLOCK));
 
     if (context.bytesSent() == data.size()) {
         if (context.zeroCopy()) {
-            ntcq::ZeroCopyCounter zeroCopyCounter = 
+            ntcq::ZeroCopyCounter zeroCopyCounter =
                 d_zeroCopyQueue.push(state.counter(), data, callback);
 
             NTCCFG_WARNING_UNUSED(zeroCopyCounter);
@@ -3348,7 +3348,7 @@ ntsa::Error StreamSocket::privateSendRaw(
     BSLS_ASSERT(dataContainer->size() != 0);
 
     if (context.zeroCopy()) {
-        ntcq::ZeroCopyCounter zeroCopyCounter = 
+        ntcq::ZeroCopyCounter zeroCopyCounter =
             d_zeroCopyQueue.push(state.counter(), dataContainer, callback);
 
         NTCCFG_WARNING_UNUSED(zeroCopyCounter);
@@ -3362,7 +3362,7 @@ ntsa::Error StreamSocket::privateSendRaw(
     entry.setLength(dataContainer->size());
     entry.setTimestamp(bsls::TimeUtil::getTimer());
     entry.setZeroCopy(context.zeroCopy());
-    
+
     if (callback) {
         entry.setCallback(callback);
     }
@@ -3665,7 +3665,7 @@ ntsa::Error StreamSocket::privateOpen(
         else {
             ntsa::SocketOption socketOption;
             error = streamSocket->getOption(
-                &socketOption, 
+                &socketOption,
                 ntsa::SocketOptionType::e_ZERO_COPY);
             if (error) {
                 NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED();
@@ -4260,8 +4260,13 @@ ntsa::Error StreamSocket::privateTimestampOutgoingData(
     if (enable) {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
         if (!reactorRef || !reactorRef->supportsNotifications()) {
-            error = ntsa::Error::e_NOT_IMPLEMENTED;
-            return error;
+            return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+        }
+
+        if (d_sendCounter != 0) {
+            NTCI_LOG_DEBUG("Outgoing timestamping may not be enabled after "
+                           "data has been sent");
+            return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
         }
 
         ntsa::SocketOption option;
@@ -4328,7 +4333,7 @@ ntsa::Error StreamSocket::privateTimestampIncomingData(
 
     d_options.setTimestampIncomingData(enable);
     d_timestampIncomingData = enable;
-    
+
     if (enable) {
         d_receiveOptions.showTimestamp();
     }
@@ -4467,7 +4472,6 @@ StreamSocket::StreamSocket(
 , d_receiveRateLimiter_sp()
 , d_receiveRateTimer_sp()
 , d_receiveGreedily(NTCCFG_DEFAULT_STREAM_SOCKET_READ_GREEDILY)
-, d_receiveCount(0)
 , d_receiveBlob_sp()
 , d_connectEndpoint()
 , d_connectName(basicAllocator)
@@ -4584,9 +4588,9 @@ StreamSocket::StreamSocket(
         d_metrics_sp = metrics;
     }
 
-    d_timestampIncomingData = 
+    d_timestampIncomingData =
         d_options.timestampIncomingData().value_or(false);
-    
+
     if (d_timestampIncomingData) {
         d_receiveOptions.showTimestamp();
     }
@@ -5782,7 +5786,7 @@ ntsa::Error StreamSocket::setZeroCopyThreshold(bsl::size_t value)
         }
 
         ntsa::SocketOption socketOption;
-        error = d_socket_sp->getOption(&socketOption, 
+        error = d_socket_sp->getOption(&socketOption,
                                        ntsa::SocketOptionType::e_ZERO_COPY);
         if (error) {
             return error;

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -1893,7 +1893,7 @@ void StreamSocket::privateShutdownSequence(
 
     if (context.shutdownCompleted()) {
         ntci::SocketDetachedCallback detachCallback(
-            NTCCFG_BIND(&StreamSocket::privateShutdownSequencePart2,
+            NTCCFG_BIND(&StreamSocket::privateShutdownSequenceComplete,
                         this,
                         self,
                         context,
@@ -1923,17 +1923,18 @@ void StreamSocket::privateShutdownSequence(
     }
 
     if (!asyncDetachmentStarted) {
-        privateShutdownSequencePart2(self, context, defer, false);
+        privateShutdownSequenceComplete(self, context, defer, false);
     }
 }
 
-void StreamSocket::privateShutdownSequencePart2(
+void StreamSocket::privateShutdownSequenceComplete(
     const bsl::shared_ptr<StreamSocket>& self,
     const ntcs::ShutdownContext&         context,
     bool                                 defer,
     bool                                 lock)
 {
     NTCI_LOG_CONTEXT();
+
     if (lock) {
         d_mutex.lock();
         BSLS_ASSERT(d_detachState.get() ==

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -3970,8 +3970,7 @@ ntsa::Error StreamSocket::privateOpen(
             option.makeZeroCopy(true);
             error = streamSocket->setOption(option);
             if (error) {
-                NTCI_LOG_WARN("ZeroCopy was requested but the OS refused to "
-                              "enable it, continue in normal mode");
+                NTCI_LOG_DEBUG("Zero-copy was requested but not supported");
                 d_zeroCopyThreshold = bsl::numeric_limits<bsl::size_t>::max();
             }
             else {

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -303,6 +303,9 @@ namespace {
 // to be zero-copied.
 const bsl::size_t k_ZERO_COPY_NEVER = (bsl::size_t)(-1);
 
+// The default zero-copy threshold value if none is explicitly specified.
+const bsl::size_t k_ZERO_COPY_DEFAULT = k_ZERO_COPY_NEVER;
+
 } // close unnamed namespace
 
 void StreamSocket::processSocketReadable(const ntca::ReactorEvent& event)
@@ -3649,6 +3652,32 @@ ntsa::Error StreamSocket::privateOpen(
         return error;
     }
 
+    if (d_options.zeroCopyThreshold().has_value()) {
+        d_zeroCopyThreshold = d_options.zeroCopyThreshold().value();
+    }
+
+    if (d_zeroCopyThreshold != k_ZERO_COPY_NEVER) {
+        ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+        if (!reactorRef || !reactorRef->supportsNotifications()) {
+            NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED();
+            d_zeroCopyThreshold = k_ZERO_COPY_NEVER;
+        }
+        else {
+            ntsa::SocketOption socketOption;
+            error = streamSocket->getOption(
+                &socketOption, 
+                ntsa::SocketOptionType::e_ZERO_COPY);
+            if (error) {
+                NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED();
+                d_zeroCopyThreshold = k_ZERO_COPY_NEVER;
+            }
+            else if (!socketOption.isZeroCopy() || !socketOption.zeroCopy()) {
+                NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED();
+                d_zeroCopyThreshold = k_ZERO_COPY_NEVER;
+            }
+        }
+    }
+
     error = streamSocket->setBlocking(false);
     if (error) {
         return error;
@@ -3714,19 +3743,6 @@ ntsa::Error StreamSocket::privateOpen(
 
     d_sendOptions.setMaxBuffers(streamSocket->maxBuffersPerSend());
     d_receiveOptions.setMaxBuffers(streamSocket->maxBuffersPerReceive());
-
-    {
-        ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-
-        if (d_options.zeroCopyThreshold().has_value() && reactorRef &&
-            reactorRef->supportsNotifications())
-        {
-            d_zeroCopyThreshold = d_options.zeroCopyThreshold().value();
-        }
-        else {
-            d_zeroCopyThreshold = k_ZERO_COPY_NEVER;
-        }
-    }
 
     {
         ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
@@ -4436,7 +4452,7 @@ StreamSocket::StreamSocket(
 , d_flowControlState()
 , d_shutdownState()
 , d_zeroCopyQueue(reactor->dataPool(), basicAllocator)
-, d_zeroCopyThreshold(k_ZERO_COPY_NEVER)
+, d_zeroCopyThreshold(k_ZERO_COPY_DEFAULT)
 , d_sendOptions()
 , d_sendQueue(basicAllocator)
 , d_sendRateLimiter_sp()
@@ -5755,16 +5771,24 @@ ntsa::Error StreamSocket::setZeroCopyThreshold(bsl::size_t value)
         return ntsa::Error();
     }
 
-    ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
-    if (!reactorRef) {
-        return ntsa::Error(ntsa::Error::e_INVALID);
+    if (value != k_ZERO_COPY_NEVER) {
+        ntcs::ObserverRef<ntci::Reactor> reactorRef(&d_reactor);
+        if (!reactorRef) {
+            return ntsa::Error(ntsa::Error::e_INVALID);
+        }
+
+        if (!reactorRef->supportsNotifications()) {
+            return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
+        }
+
+        ntsa::SocketOption socketOption;
+        error = d_socket_sp->getOption(&socketOption, 
+                                       ntsa::SocketOptionType::e_ZERO_COPY);
+        if (error) {
+            return error;
+        }
     }
 
-    if (!reactorRef->supportsNotifications()) {
-        return ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED);
-    }
-
-    d_options.setZeroCopyThreshold(value);
     d_zeroCopyThreshold = value;
 
     return ntsa::Error();

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -162,7 +162,7 @@ BSLS_IDENT_RCSID(ntcr_streamsocket_cpp, "$Id$ $CSID$")
                    "has saturated the socket send buffer")
 
 #define NTCR_STREAMSOCKET_LOG_SEND_BUFFER_PAGE_LIMIT()                        \
-    NTCI_LOG_ERROR("Stream socket "                                           \
+    NTCI_LOG_TRACE("Stream socket "                                           \
                    "has saturated the number of pinned pages")
 
 #define NTCR_STREAMSOCKET_LOG_ZERO_COPY_DISABLED()                            \
@@ -4680,7 +4680,7 @@ StreamSocket::StreamSocket(
 , d_openState()
 , d_flowControlState()
 , d_shutdownState()
-, d_zeroCopyList(basicAllocator)
+, d_zeroCopyList(reactor->dataPool(), basicAllocator)
 , d_zeroCopyThreshold(bsl::numeric_limits<bsl::size_t>::max())
 , d_sendOptions()
 , d_sendQueue(basicAllocator)

--- a/groups/ntc/ntcr/ntcr_streamsocket.cpp
+++ b/groups/ntc/ntcr/ntcr_streamsocket.cpp
@@ -3140,9 +3140,6 @@ ntsa::Error StreamSocket::privateSendRaw(
         }
     }
 
-    BSLS_ASSERT((!error && context.bytesSent() > 0) || 
-                 (error == ntsa::Error::e_WOULD_BLOCK));
-
     if (context.bytesSent() == static_cast<bsl::size_t>(data.length())) {
         if (context.zeroCopy()) {
             d_zeroCopyQueue.push(state.counter(), data, callback);

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -321,7 +321,7 @@ class StreamSocket : public ntci::StreamSocket,
 
     /// Execute the second part of shutdown sequence when the socket is
     /// detached. See also "privateShutdownSequence"
-    void privateShutdownSequencePart2(
+    void privateShutdownSequenceComplete(
         const bsl::shared_ptr<StreamSocket>& self,
         const ntcs::ShutdownContext&         context,
         bool                                 defer,

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -521,21 +521,22 @@ class StreamSocket : public ntci::StreamSocket,
     ntsa::Error privateRetryConnectToEndpoint(
         const bsl::shared_ptr<StreamSocket>& self);
 
-    /// Request the OS to enable transmis timestamps if the specified 'enable'
-    /// is true. Return true in case of success. Return false otherwise.
-    ntsa::Error privateTimestampOutgoingData(bool enable);
+    /// Enable or disable timestamping of outgoing data according to the 
+    /// specified 'enable' flag. Return the error.
+    ntsa::Error privateTimestampOutgoingData(
+        const bsl::shared_ptr<StreamSocket>& self,
+        bool                                 enable);
 
-    /// Start timestamping outgoing data. Prepare buffers and request the OS to
-    /// enable transmit timestamps. Return no error in case of success,
-    /// return error otherwise.
-    ntsa::Error startTimestampOutgoingData();
+    /// Process the detection of the specified outgoing data 'timestamp'.
+    void privateTimestampUpdate(
+            const bsl::shared_ptr<StreamSocket>& self,
+            const ntsa::Timestamp&               timestamp);
 
-    /// Stop timestamping outgoing data. Return no error in case of success,
-    /// return error otherwise.
-    ntsa::Error stopTimestampOutgoingData();
-
-    /// Process notification containing the specified 'timestamp'.
-    void processTimestampNotification(const ntsa::Timestamp& timestamp);
+    // Process the completion of one or more zero-copy tranmsissions described
+    // by the specified 'zeroCopy' notification.
+    void privateZeroCopyUpdate(
+            const bsl::shared_ptr<StreamSocket>& self,
+            const ntsa::ZeroCopy&                zeroCopy);
 
   public:
     /// Create a new, initially uninitilialized stream socket. Optionally
@@ -1152,6 +1153,11 @@ class StreamSocket : public ntci::StreamSocket,
                                        bsl::size_t highWatermark)
         BSLS_KEYWORD_OVERRIDE;
 
+    /// Request the implementation to start timestamping outgoing data if the
+    /// specified 'enable' flag is true. Otherwise, request the implementation
+    /// to stop timestamping outgoing data. Return the error.
+    ntsa::Error timestampOutgoingData(bool enable) BSLS_KEYWORD_OVERRIDE;
+
     /// Enable copying from the socket buffers in the specified 'direction'.
     ntsa::Error relaxFlowControl(ntca::FlowControlType::Value direction)
         BSLS_KEYWORD_OVERRIDE;
@@ -1275,13 +1281,6 @@ class StreamSocket : public ntci::StreamSocket,
     /// buffer allocated from the outgoing blob buffer factory.
     void createOutgoingBlobBuffer(bdlbb::BlobBuffer* blobBuffer)
         BSLS_KEYWORD_OVERRIDE;
-
-    /// Request the implementation to start timestamping outgoing data if the
-    /// specified 'enable' flag is true. Otherwise, request the implementation
-    /// to stop timestamping outgoing data. Return true if operation was
-    /// successful (though it does not guarantee that transmit timestamps would
-    /// be generated). Otherwise return false.
-    ntsa::Error timestampOutgoingData(bool enable) BSLS_KEYWORD_OVERRIDE;
 
     /// Return the descriptor handle.
     ntsa::Handle handle() const BSLS_KEYWORD_OVERRIDE;

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -124,7 +124,6 @@ class StreamSocket : public ntci::StreamSocket,
     bsl::shared_ptr<ntci::RateLimiter>         d_receiveRateLimiter_sp;
     bsl::shared_ptr<ntci::Timer>               d_receiveRateTimer_sp;
     bool                                       d_receiveGreedily;
-    bsl::uint64_t                              d_receiveCount;
     bsl::shared_ptr<bdlbb::Blob>               d_receiveBlob_sp;
     ntsa::Endpoint                             d_connectEndpoint;
     bsl::string                                d_connectName;
@@ -279,11 +278,6 @@ class StreamSocket : public ntci::StreamSocket,
     void privateFail(const bsl::shared_ptr<StreamSocket>& self,
                      const ntsa::Error&                   error);
 
-    /// Indicate a failure has occurred and detach the socket from its
-    /// monitor.
-    void privateFail(const bsl::shared_ptr<StreamSocket>& self,
-                     const ntca::ErrorEvent&              event);
-
     /// Shutdown the stream socket in the specified 'direction' according
     /// to the specified 'mode' of shutdown. Return the error.
     ntsa::Error privateShutdown(const bsl::shared_ptr<StreamSocket>& self,
@@ -407,7 +401,7 @@ class StreamSocket : public ntci::StreamSocket,
     /// if necessary.
     void privateRearmAfterReceive(const bsl::shared_ptr<StreamSocket>& self);
 
-    /// Rearm the interest in notifications from the socket in the reactor. 
+    /// Rearm the interest in notifications from the socket in the reactor.
     void privateRearmAfterNotification(
         const bsl::shared_ptr<StreamSocket>& self);
 
@@ -535,13 +529,13 @@ class StreamSocket : public ntci::StreamSocket,
     ntsa::Error privateRetryConnectToEndpoint(
         const bsl::shared_ptr<StreamSocket>& self);
 
-    /// Enable or disable timestamping of outgoing data according to the 
+    /// Enable or disable timestamping of outgoing data according to the
     /// specified 'enable' flag. Return the error.
     ntsa::Error privateTimestampOutgoingData(
         const bsl::shared_ptr<StreamSocket>& self,
         bool                                 enable);
 
-    /// Enable or disable timestamping of incoming data according to the 
+    /// Enable or disable timestamping of incoming data according to the
     /// specified 'enable' flag. Return the error.
     ntsa::Error privateTimestampIncomingData(
         const bsl::shared_ptr<StreamSocket>& self,

--- a/groups/ntc/ntcr/ntcr_streamsocket.h
+++ b/groups/ntc/ntcr/ntcr_streamsocket.h
@@ -528,6 +528,12 @@ class StreamSocket : public ntci::StreamSocket,
         const bsl::shared_ptr<StreamSocket>& self,
         bool                                 enable);
 
+    /// Enable or disable timestamping of incoming data according to the 
+    /// specified 'enable' flag. Return the error.
+    ntsa::Error privateTimestampIncomingData(
+        const bsl::shared_ptr<StreamSocket>& self,
+        bool                                 enable);
+
     /// Process the detection of the specified outgoing data 'timestamp'.
     void privateTimestampUpdate(
             const bsl::shared_ptr<StreamSocket>& self,

--- a/groups/ntc/ntcs/ntcs_compat.cpp
+++ b/groups/ntc/ntcs/ntcs_compat.cpp
@@ -24,6 +24,10 @@ BSLS_IDENT_RCSID(ntcs_compat_cpp, "$Id$ $CSID$")
 #include <ntsu_socketoptionutil.h>
 #include <bsls_atomic.h>
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+#include <errno.h>
+#endif
+
 // Define to 1 to configure send timeouts, or define to 0 to ignore the
 // requested send timeout configuration.
 #define NTCS_COMPAT_CONFIGURE_SEND_TIMEOUT 0
@@ -31,6 +35,14 @@ BSLS_IDENT_RCSID(ntcs_compat_cpp, "$Id$ $CSID$")
 // Define to 1 to configure receive timeouts, or define to 0 to ignore the
 // requested receive timeout configuration.
 #define NTCS_COMPAT_CONFIGURE_RECEIVE_TIMEOUT 0
+
+// Define to 1 to configure zero-copy support, or define to 0 to leave
+// zero-copy support as the default setting.
+#if defined(BSLS_PLATFORM_OS_LINUX)
+#define NTCS_COMPAT_CONFIGURE_ZERO_COPY 1
+#else
+#define NTCS_COMPAT_CONFIGURE_ZERO_COPY 0
+#endif
 
 namespace BloombergLP {
 namespace ntcs {
@@ -1388,6 +1400,26 @@ ntsa::Error Compat::configure(
         }
     }
 
+#if defined(BSLS_PLATFORM_OS_LINUX) && NTCS_COMPAT_CONFIGURE_ZERO_COPY
+
+    // In order for the kernel to respect the MSG_ZEROCOPY flag in ::sendmsg
+    // the SO_ZEROCOPY option must first be set. This option may only be
+    // set when the socket is in the default state, on certain Linux kernel
+    // versions. 
+
+    {
+        ntsa::SocketOption option;
+        option.makeZeroCopy(true);
+
+        error = socket->setOption(option);
+        if (error && error.number() != EBUSY) {
+            BSLS_LOG_DEBUG("Failed to set socket option: zero-copy: %s",
+                           error.text().c_str());
+        }
+    }
+
+#endif
+
     return ntsa::Error();
 }
 
@@ -1629,6 +1661,26 @@ ntsa::Error Compat::configure(
             }
         }
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX) && NTCS_COMPAT_CONFIGURE_ZERO_COPY
+
+    // In order for the kernel to respect the MSG_ZEROCOPY flag in ::sendmsg
+    // the SO_ZEROCOPY option must first be set. This option may only be
+    // set when the socket is in the default state, on certain Linux kernel
+    // versions. 
+
+    {
+        ntsa::SocketOption option;
+        option.makeZeroCopy(true);
+
+        error = socket->setOption(option);
+        if (error && error.number() != EBUSY) {
+            BSLS_LOG_DEBUG("Failed to set socket option: zero-copy: %s",
+                           error.text().c_str());
+        }
+    }
+
+#endif
 
     return ntsa::Error();
 }
@@ -1903,6 +1955,26 @@ ntsa::Error Compat::configure(
             }
         }
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX) && NTCS_COMPAT_CONFIGURE_ZERO_COPY
+
+    // In order for the kernel to respect the MSG_ZEROCOPY flag in ::sendmsg
+    // the SO_ZEROCOPY option must first be set. This option may only be
+    // set when the socket is in the default state, on certain Linux kernel
+    // versions. 
+
+    {
+        ntsa::SocketOption option;
+        option.makeZeroCopy(true);
+
+        error = socket->setOption(option);
+        if (error && error.number() != EBUSY) {
+            BSLS_LOG_DEBUG("Failed to set socket option: zero-copy: %s",
+                           error.text().c_str());
+        }
+    }
+
+#endif
 
     return ntsa::Error();
 }

--- a/groups/ntc/ntcs/ntcs_compat.cpp
+++ b/groups/ntc/ntcs/ntcs_compat.cpp
@@ -316,7 +316,6 @@ void Compat::convert(ntca::StreamSocketOptions*         result,
             options.timestampIncomingData().value());
     }
 
-    //TODO: modify functions below accordingly
     if (!options.zeroCopyThreshold().isNull()) {
         result->setZeroCopyThreshold(options.zeroCopyThreshold().value());
     }
@@ -454,7 +453,6 @@ void Compat::convert(ntca::ListenerSocketOptions*     result,
     result->setLoadBalancingOptions(options.loadBalancingOptions());
 }
 
-//TODO: timestamping? ZeroCopy?
 void Compat::convert(ntca::DatagramSocketOptions*       result,
                      const ntca::DatagramSocketOptions& options,
                      const ntca::InterfaceConfig&       config)
@@ -533,6 +531,26 @@ void Compat::convert(ntca::DatagramSocketOptions*       result,
     if (result->receiveTimeout().isNull()) {
         if (!config.receiveTimeout().isNull()) {
             result->setReceiveTimeout(config.receiveTimeout().value());
+        }
+    }
+
+    if (result->timestampOutgoingData().isNull()) {
+        if (!config.timestampOutgoingData().isNull()) {
+            result->setTimestampOutgoingData(
+                config.timestampOutgoingData().value());
+        }
+    }
+
+    if (result->timestampIncomingData().isNull()) {
+        if (!config.timestampIncomingData().isNull()) {
+            result->setTimestampIncomingData(
+                config.timestampIncomingData().value());
+        }
+    }
+
+    if (result->zeroCopyThreshold().isNull()) {
+        if (!config.zeroCopyThreshold().isNull()) {
+            result->setZeroCopyThreshold(config.zeroCopyThreshold().value());
         }
     }
 
@@ -726,6 +744,26 @@ void Compat::convert(ntca::ListenerSocketOptions*       result,
         }
     }
 
+    if (result->timestampOutgoingData().isNull()) {
+        if (!config.timestampOutgoingData().isNull()) {
+            result->setTimestampOutgoingData(
+                config.timestampOutgoingData().value());
+        }
+    }
+
+    if (result->timestampIncomingData().isNull()) {
+        if (!config.timestampIncomingData().isNull()) {
+            result->setTimestampIncomingData(
+                config.timestampIncomingData().value());
+        }
+    }
+
+    if (result->zeroCopyThreshold().isNull()) {
+        if (!config.zeroCopyThreshold().isNull()) {
+            result->setZeroCopyThreshold(config.zeroCopyThreshold().value());
+        }
+    }
+
     if (result->keepAlive().isNull()) {
         if (!config.keepAlive().isNull()) {
             result->setKeepAlive(config.keepAlive().value());
@@ -887,6 +925,26 @@ void Compat::convert(ntca::StreamSocketOptions*       result,
     if (result->receiveTimeout().isNull()) {
         if (!config.receiveTimeout().isNull()) {
             result->setReceiveTimeout(config.receiveTimeout().value());
+        }
+    }
+
+    if (result->timestampOutgoingData().isNull()) {
+        if (!config.timestampOutgoingData().isNull()) {
+            result->setTimestampOutgoingData(
+                config.timestampOutgoingData().value());
+        }
+    }
+
+    if (result->timestampIncomingData().isNull()) {
+        if (!config.timestampIncomingData().isNull()) {
+            result->setTimestampIncomingData(
+                config.timestampIncomingData().value());
+        }
+    }
+
+    if (result->zeroCopyThreshold().isNull()) {
+        if (!config.zeroCopyThreshold().isNull()) {
+            result->setZeroCopyThreshold(config.zeroCopyThreshold().value());
         }
     }
 

--- a/groups/ntc/ntcs/ntcs_compat.cpp
+++ b/groups/ntc/ntcs/ntcs_compat.cpp
@@ -1872,6 +1872,22 @@ ntsa::Error Compat::configure(
         }
     }
 
+    if (!options.timestampOutgoingData().isNull()) {
+        ntsa::SocketOption option;
+        option.makeTimestampOutgoingData(
+            options.timestampOutgoingData().value());
+
+        error = socket->setOption(option);
+        if (error) {
+            BSLS_LOG_DEBUG("Failed to set socket option: "
+                           "timestamp outcoming data: %s",
+                           error.text().c_str());
+            if (error != ntsa::Error(ntsa::Error::e_NOT_IMPLEMENTED)) {
+                return error;
+            }
+        }
+    }
+
     if (!options.timestampIncomingData().isNull()) {
         ntsa::SocketOption option;
         option.makeTimestampIncomingData(

--- a/groups/nts/ntsa/ntsa_notification.t.cpp
+++ b/groups/nts/ntsa/ntsa_notification.t.cpp
@@ -131,8 +131,8 @@ NTSCFG_TEST_CASE(6)
     NTSCFG_TEST_EQ(n.type(), NotificationType::e_ZERO_COPY);
 
     zc.setFrom(1);
-    zc.setTo(22);
-    zc.setCode(1);
+    zc.setThru(22);
+    zc.setType(ntsa::ZeroCopyType::e_DEFERRED);
     NTSCFG_TEST_EQ(n.zeroCopy(), zc);
 }
 
@@ -140,8 +140,8 @@ NTSCFG_TEST_CASE(7)
 {
     ZeroCopy zc;
     zc.setFrom(1);
-    zc.setTo(22);
-    zc.setCode(1);
+    zc.setThru(22);
+    zc.setType(ntsa::ZeroCopyType::e_DEFERRED);
 
     Notification n;
     n.makeZeroCopy(zc);

--- a/groups/nts/ntsa/ntsa_sendcontext.cpp
+++ b/groups/nts/ntsa/ntsa_sendcontext.cpp
@@ -30,7 +30,8 @@ bool SendContext::equals(const SendContext& other) const
            d_buffersSendable == other.d_buffersSendable &&
            d_buffersSent == other.d_buffersSent &&
            d_messagesSendable == other.d_messagesSendable &&
-           d_messagesSent == other.d_messagesSent;
+           d_messagesSent == other.d_messagesSent && 
+           d_zeroCopy == other.d_zeroCopy;
 }
 
 bool SendContext::less(const SendContext& other) const
@@ -75,7 +76,15 @@ bool SendContext::less(const SendContext& other) const
         return false;
     }
 
-    return d_messagesSent < other.d_messagesSent;
+    if (d_messagesSent < other.d_messagesSent) {
+        return true;
+    }
+
+    if (other.d_messagesSent < d_messagesSent) {
+        return false;
+    }
+
+    return d_zeroCopy < other.d_zeroCopy;
 }
 
 bsl::ostream& SendContext::print(bsl::ostream& stream,
@@ -90,6 +99,7 @@ bsl::ostream& SendContext::print(bsl::ostream& stream,
     printer.printAttribute("buffersSent", d_buffersSent);
     printer.printAttribute("messagesSendable", d_messagesSendable);
     printer.printAttribute("messagesSent", d_messagesSent);
+    printer.printAttribute("zeroCopy", d_zeroCopy);
     printer.end();
     return stream;
 }

--- a/groups/nts/ntsa/ntsa_sendcontext.h
+++ b/groups/nts/ntsa/ntsa_sendcontext.h
@@ -36,7 +36,7 @@ namespace ntsa {
 /// @par Attributes
 /// This class is composed of the following attributes.
 ///
-/// @li @b  bytesSendable:
+/// @li @b bytesSendable:
 /// The number of bytes attempted to copy to the socket send buffer.
 ///
 /// @li @b bytesSent:

--- a/groups/nts/ntsa/ntsa_sendcontext.h
+++ b/groups/nts/ntsa/ntsa_sendcontext.h
@@ -57,6 +57,13 @@ namespace ntsa {
 /// The actual number of messages copied to the socket send buffer. This value
 /// is only relevant when copying to the send buffer of a datagram socket.
 ///
+/// @li @b zeroCopy:
+/// The flag that indicates the data was referenced in-place rather than copied
+/// to the send buffer. If this flag is true, the application must ensure the
+/// data-to-send is neither overwritten nor invalidated (i.e. freed) until the
+/// completion of the send operation is indicated in a subsequent notification
+/// (which also indicates whether the data was referenced in-place or copied.)
+///
 /// @par Thread Safety
 /// This class is not thread safe.
 ///
@@ -69,6 +76,7 @@ class SendContext
     bsl::size_t d_buffersSent;
     bsl::size_t d_messagesSendable;
     bsl::size_t d_messagesSent;
+    bool        d_zeroCopy;
 
   public:
     /// Create new send options having the default value.
@@ -110,6 +118,10 @@ class SendContext
     /// Set the number of messages actually sent to the specified 'value'.
     void setMessagesSent(bsl::size_t value);
 
+    /// Set the flag that indicates the data was referenced in-place rather
+    /// than copied to the send buffer to the specified 'value'.
+    void setZeroCopy(bool value);
+
     /// Return the number of bytes attempted to be sent.
     bsl::size_t bytesSendable() const;
 
@@ -127,6 +139,10 @@ class SendContext
 
     /// Return the number of messages actually sent.
     bsl::size_t messagesSent() const;
+
+    /// Return the flag that indicates the data was referenced in-place rather
+    /// than copied to the send buffer.
+    bool zeroCopy() const;
 
     /// Return true if this object has the same value as the specified
     /// 'other' object, otherwise return false.
@@ -196,6 +212,7 @@ SendContext::SendContext()
 , d_buffersSent(0)
 , d_messagesSendable(0)
 , d_messagesSent(0)
+, d_zeroCopy(false)
 {
 }
 
@@ -207,6 +224,7 @@ SendContext::SendContext(const SendContext& original)
 , d_buffersSent(original.d_buffersSent)
 , d_messagesSendable(original.d_messagesSendable)
 , d_messagesSent(original.d_messagesSent)
+, d_zeroCopy(original.d_zeroCopy)
 {
 }
 
@@ -224,6 +242,7 @@ SendContext& SendContext::operator=(const SendContext& other)
     d_buffersSent      = other.d_buffersSent;
     d_messagesSendable = other.d_messagesSendable;
     d_messagesSent     = other.d_messagesSent;
+    d_zeroCopy         = other.d_zeroCopy;
 
     return *this;
 }
@@ -237,6 +256,7 @@ void SendContext::reset()
     d_buffersSent      = 0;
     d_messagesSendable = 0;
     d_messagesSent     = 0;
+    d_zeroCopy         = false;
 }
 
 NTSCFG_INLINE
@@ -276,6 +296,12 @@ void SendContext::setMessagesSent(bsl::size_t value)
 }
 
 NTSCFG_INLINE
+void SendContext::setZeroCopy(bool value)
+{
+    d_zeroCopy = value;
+}
+
+NTSCFG_INLINE
 bsl::size_t SendContext::bytesSendable() const
 {
     return d_bytesSendable;
@@ -309,6 +335,12 @@ NTSCFG_INLINE
 bsl::size_t SendContext::messagesSent() const
 {
     return d_messagesSent;
+}
+
+NTSCFG_INLINE
+bool SendContext::zeroCopy() const
+{
+    return d_zeroCopy;
 }
 
 NTSCFG_INLINE
@@ -346,6 +378,7 @@ void hashAppend(HASH_ALGORITHM& algorithm, const SendContext& value)
     hashAppend(algorithm, value.buffersSent());
     hashAppend(algorithm, value.messagesSendable());
     hashAppend(algorithm, value.messagesSent());
+    hashAppend(algorithm, value.zeroCopy());
 }
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_sendoptions.h
+++ b/groups/nts/ntsa/ntsa_sendoptions.h
@@ -81,13 +81,13 @@ namespace ntsa {
 ///
 /// @li @b zeroCopy:
 /// The flag to request the data-to-send be referenced in-place rather than
-/// copied to the send buffer to the specified 'value'. Note that this flag is
-/// advisory; the operating system may neither support nor decide to allow
-/// zero-copy semantics. Regardless, if zero-copy semantics are requested the
-/// application must ensure the data-to-send is neither overwritten nor
-/// invalidated (i.e. freed) until the completion of the send operation is
-/// indicated in a subsequent notification (which also indicates whether the
-/// data was referenced in-place or copied.)
+/// copied to the send buffer. Note that this flag is advisory; the operating
+/// system may neither support nor decide to allow zero-copy semantics.
+/// Regardless, if zero-copy semantics are requested the application must
+/// ensure the data-to-send is neither overwritten nor invalidated (i.e. freed)
+/// until the completion of the send operation is indicated in a subsequent
+/// notification (which also indicates whether the data was referenced in-place
+/// or copied.)
 ///
 /// @par Thread Safety
 /// This class is not thread safe.

--- a/groups/nts/ntsa/ntsa_zerocopy.cpp
+++ b/groups/nts/ntsa/ntsa_zerocopy.cpp
@@ -18,15 +18,69 @@
 #include <bsls_ident.h>
 BSLS_IDENT_RCSID(ntsa_zerocopy_cpp, "$Id$ $CSID$")
 
+#include <bdlb_string.h>
 #include <bslim_printer.h>
 
 namespace BloombergLP {
 namespace ntsa {
 
+int ZeroCopyType::fromInt(ZeroCopyType::Value* result, int number)
+{
+    switch (number) {
+    case ZeroCopyType::e_AVOIDED:
+    case ZeroCopyType::e_DEFERRED:
+        *result = static_cast<ZeroCopyType::Value>(number);
+        return 0;
+    default:
+        return -1;
+    }
+}
+
+int ZeroCopyType::fromString(ZeroCopyType::Value*     result,
+                             const bslstl::StringRef& string)
+{
+    if (bdlb::String::areEqualCaseless(string, "AVOIDED")) {
+        *result = e_AVOIDED;
+        return 0;
+    }
+    if (bdlb::String::areEqualCaseless(string, "DEFERRED")) {
+        *result = e_DEFERRED;
+        return 0;
+    }
+
+    return -1;
+}
+
+const char* ZeroCopyType::toString(ZeroCopyType::Value value)
+{
+    switch (value) {
+    case e_AVOIDED: {
+        return "AVOIDED";
+    } break;
+    case e_DEFERRED: {
+        return "DEFERRED";
+    } break;
+    }
+
+    BSLS_ASSERT(!"invalid enumerator");
+    return 0;
+}
+
+bsl::ostream& ZeroCopyType::print(bsl::ostream&       stream,
+                                  ZeroCopyType::Value value)
+{
+    return stream << toString(value);
+}
+
+bsl::ostream& operator<<(bsl::ostream& stream, ZeroCopyType::Value rhs)
+{
+    return ZeroCopyType::print(stream, rhs);
+}
+
 bool ZeroCopy::equals(const ZeroCopy& other) const
 {
-    return (d_from == other.d_from && d_to == other.d_to &&
-            d_code == other.d_code);
+    return (d_from == other.d_from && d_thru == other.d_thru &&
+            d_type == other.d_type);
 }
 
 bool ZeroCopy::less(const ZeroCopy& other) const
@@ -39,15 +93,15 @@ bool ZeroCopy::less(const ZeroCopy& other) const
         return false;
     }
 
-    if (d_to < other.d_to) {
+    if (d_thru < other.d_thru) {
         return true;
     }
 
-    if (other.d_to < d_to) {
+    if (other.d_thru < d_thru) {
         return false;
     }
 
-    return d_code < other.d_code;
+    return d_type < other.d_type;
 }
 
 bsl::ostream& ZeroCopy::print(bsl::ostream& stream,
@@ -57,8 +111,8 @@ bsl::ostream& ZeroCopy::print(bsl::ostream& stream,
     bslim::Printer printer(&stream, level, spacesPerLevel);
     printer.start();
     printer.printAttribute("from", d_from);
-    printer.printAttribute("to", d_to);
-    printer.printAttribute("code", d_code);
+    printer.printAttribute("thru", d_thru);
+    printer.printAttribute("type", d_type);
     printer.end();
     return stream;
 }

--- a/groups/nts/ntsa/ntsa_zerocopy.h
+++ b/groups/nts/ntsa/ntsa_zerocopy.h
@@ -27,8 +27,53 @@ BSLS_IDENT("$Id: $")
 namespace BloombergLP {
 namespace ntsa {
 
-/// Describe a notification for the completion of one or more send operations
-/// with zero-copy semantics.
+/// Provide an enumeration of the status of a zero-copy operation.
+///
+/// @par Thread Safety
+/// This struct is thread safe.
+///
+/// @ingroup module_ntsa_system
+struct ZeroCopyType {
+  public:
+    /// Provide an enumeration of the status of a zero-copy operation.
+    enum Value {
+        /// The copy was avoided.
+        e_AVOIDED = 0,
+
+        /// The copy was deferred from the time of the system call until
+        /// nearer to the time of transmission but a deep copy was still 
+        /// performed.
+        e_DEFERRED = 1
+    };
+
+    /// Return the string representation exactly matching the enumerator name
+    /// corresponding to the specified enumeration 'value'.
+    static const char* toString(Value value);
+
+    /// Load into the specified 'result' the enumerator matching the specified
+    /// 'string'.  Return 0 on success, and a non-zero value with no effect on
+    /// 'result' otherwise (i.e., 'string' does not match any enumerator).
+    static int fromString(Value* result, const bslstl::StringRef& string);
+
+    /// Load into the specified 'result' the enumerator matching the specified
+    /// 'number'.  Return 0 on success, and a non-zero value with no effect on
+    /// 'result' otherwise (i.e., 'number' does not match any enumerator).
+    static int fromInt(Value* result, int number);
+
+    /// Write to the specified 'stream' the string representation of the
+    /// specified enumeration 'value'.  Return a reference to the modifiable
+    /// 'stream'.
+    static bsl::ostream& print(bsl::ostream& stream, Value value);
+};
+
+/// Format the specified 'rhs' to the specified output 'stream' and return a
+/// reference to the modifiable 'stream'.
+///
+/// @related ntsa::ZeroCopyType
+bsl::ostream& operator<<(bsl::ostream& stream, ZeroCopyType::Value rhs);
+
+/// Describe a notification for the completion of a closed range of send
+/// operations with zero-copy semantics.
 ///
 /// @par Attributes
 /// This class is composed of the following attributes:
@@ -36,27 +81,33 @@ namespace ntsa {
 /// @li @b from:
 /// The identifier of the first zero-copy send that completed, inclusive.
 ///
-/// @li @b to:
+/// @li @b thru:
 /// The identifier of the last zero-copy send that completed, inclusive.
 ///
-/// @li @b code:
-/// The code indicating whether the copy was avoided or was performed.
+/// @li @b type:
+/// The status of the zero-copy operation. This enumerated indicates whether
+/// a copy was avoided or was deferred from the time of the system call until
+/// later, more nearer to the time of transmission.
 ///
 /// @par Thread Safety
 /// This class is not thread safe.
+///
+/// @ingroup module_ntsa_system
 class ZeroCopy
 {
-    bsl::uint32_t d_from;
-    bsl::uint32_t d_to;
-    bsl::uint8_t  d_code;
+    bsl::uint32_t             d_from;
+    bsl::uint32_t             d_thru;
+    ntsa::ZeroCopyType::Value d_type;
 
   public:
-    /// Create a new instance having the default value.
+    /// Create a new zero-copy interval having the default value.
     ZeroCopy();
 
-    /// Create a new instance using the specified 'from', the specified 'to'
-    /// and the specified 'code' as initial values.
-    ZeroCopy(bsl::uint32_t from, bsl::uint32_t to, bsl::uint8_t code);
+    /// Create a new '[from, thru]' zero-copy interval completed according to
+    /// the specified 'type'. 
+    ZeroCopy(bsl::uint32_t             from, 
+             bsl::uint32_t             thru, 
+             ntsa::ZeroCopyType::Value type);
 
     /// Create new object having the same value as the specified 'original'
     /// object.
@@ -75,11 +126,11 @@ class ZeroCopy
 
     /// Set the identifier of the last zero-copy send that completed, 
     /// inclusive, to the specified 'value'. 
-    void setTo(bsl::uint32_t value);
+    void setThru(bsl::uint32_t value);
 
-    /// Set the code indicating whether the copy was avoided or was performed
+    /// Set the type indicating whether the copy was avoided or was performed
     /// to the specified 'value'.
-    void setCode(bsl::uint8_t value);
+    void setType(ntsa::ZeroCopyType::Value value);
 
     /// Return the identifier of the first zero-copy send that completed, 
     /// inclusive.
@@ -87,11 +138,11 @@ class ZeroCopy
 
     /// Return the identifier of the last zero-copy send that completed, 
     /// inclusive.
-    BSLS_ANNOTATION_NODISCARD bsl::uint32_t to() const;
+    BSLS_ANNOTATION_NODISCARD bsl::uint32_t thru() const;
 
-    /// Return the code indicating whether the copy was avoided or was 
+    /// Return the type indicating whether the copy was avoided or was 
     /// performed.
-    BSLS_ANNOTATION_NODISCARD bsl::uint8_t code() const;
+    BSLS_ANNOTATION_NODISCARD ntsa::ZeroCopyType::Value type() const;
 
     /// Return true if this object has the same value as the specified
     /// 'other' object, otherwise return false.
@@ -121,8 +172,8 @@ class ZeroCopy
     NTSCFG_DECLARE_NESTED_BITWISE_MOVABLE_TRAITS(ZeroCopy);
 };
 
-/// Write the specified 'object' to the specified 'stream'. Return
-/// a modifiable reference to the 'stream'.
+/// Write the specified 'object' to the specified 'stream'. Return a modifiable
+/// reference to the 'stream'.
 ///
 /// @related ntsa::ZeroCopy
 bsl::ostream& operator<<(bsl::ostream& stream, const ZeroCopy& object);
@@ -139,14 +190,14 @@ bool operator==(const ZeroCopy& lhs, const ZeroCopy& rhs);
 /// @related ntsa::ZeroCopy
 bool operator!=(const ZeroCopy& lhs, const ZeroCopy& rhs);
 
-/// Return true if the value of the specified 'lhs' is less than the value
-/// of the specified 'rhs', otherwise return false.
+/// Return true if the value of the specified 'lhs' is less than the value of
+/// the specified 'rhs', otherwise return false.
 ///
 /// @related ntsa::ZeroCopy
 bool operator<(const ZeroCopy& lhs, const ZeroCopy& rhs);
 
-/// Contribute the values of the salient attributes of the specified 'value'
-/// to the specified hash 'algorithm'.
+/// Contribute the values of the salient attributes of the specified 'value' to
+/// the specified hash 'algorithm'.
 ///
 /// @related ntsa::ZeroCopy
 template <typename HASH_ALGORITHM>
@@ -155,24 +206,26 @@ void hashAppend(HASH_ALGORITHM& algorithm, const ZeroCopy& value);
 NTSCFG_INLINE
 ZeroCopy::ZeroCopy()
 : d_from(0)
-, d_to(0)
-, d_code(0)
+, d_thru(0)
+, d_type(ntsa::ZeroCopyType::e_AVOIDED)
 {
 }
 
 NTSCFG_INLINE
-ZeroCopy::ZeroCopy(bsl::uint32_t from, bsl::uint32_t to, bsl::uint8_t code)
+ZeroCopy::ZeroCopy(bsl::uint32_t             from, 
+                   bsl::uint32_t             thru, 
+                   ntsa::ZeroCopyType::Value type)
 : d_from(from)
-, d_to(to)
-, d_code(code)
+, d_thru(thru)
+, d_type(type)
 {
 }
 
 NTSCFG_INLINE
 ZeroCopy::ZeroCopy(const ZeroCopy& original)
 : d_from(original.d_from)
-, d_to(original.d_to)
-, d_code(original.d_code)
+, d_thru(original.d_thru)
+, d_type(original.d_type)
 {
 }
 
@@ -185,8 +238,8 @@ NTSCFG_INLINE
 ZeroCopy& ZeroCopy::operator=(const ZeroCopy& other)
 {
     d_from = other.d_from;
-    d_to   = other.d_to;
-    d_code = other.d_code;
+    d_thru = other.d_thru;
+    d_type = other.d_type;
     return *this;
 }
 
@@ -197,15 +250,15 @@ void ZeroCopy::setFrom(bsl::uint32_t value)
 }
 
 NTSCFG_INLINE
-void ZeroCopy::setTo(bsl::uint32_t value)
+void ZeroCopy::setThru(bsl::uint32_t value)
 {
-    d_to = value;
+    d_thru = value;
 }
 
 NTSCFG_INLINE
-void ZeroCopy::setCode(bsl::uint8_t value)
+void ZeroCopy::setType(ntsa::ZeroCopyType::Value value)
 {
-    d_code = value;
+    d_type = value;
 }
 
 NTSCFG_INLINE
@@ -215,15 +268,15 @@ bsl::uint32_t ZeroCopy::from() const
 }
 
 NTSCFG_INLINE
-bsl::uint32_t ZeroCopy::to() const
+bsl::uint32_t ZeroCopy::thru() const
 {
-    return d_to;
+    return d_thru;
 }
 
 NTSCFG_INLINE
-bsl::uint8_t ZeroCopy::code() const
+ntsa::ZeroCopyType::Value ZeroCopy::type() const
 {
-    return d_code;
+    return d_type;
 }
 
 NTSCFG_INLINE
@@ -256,8 +309,8 @@ void hashAppend(HASH_ALGORITHM& algorithm, const ZeroCopy& value)
     using bslh::hashAppend;
 
     hashAppend(algorithm, value.from());
-    hashAppend(algorithm, value.to());
-    hashAppend(algorithm, value.code());
+    hashAppend(algorithm, value.thru());
+    hashAppend(algorithm, value.type());
 }
 
 }  // close package namespace

--- a/groups/nts/ntsa/ntsa_zerocopy.t.cpp
+++ b/groups/nts/ntsa/ntsa_zerocopy.t.cpp
@@ -25,31 +25,31 @@ NTSCFG_TEST_CASE(1)
     {
         ZeroCopy zc;
         NTSCFG_TEST_EQ(zc.from(), 0);
-        NTSCFG_TEST_EQ(zc.to(), 0);
-        NTSCFG_TEST_EQ(zc.code(), 0);
+        NTSCFG_TEST_EQ(zc.thru(), 0);
+        NTSCFG_TEST_EQ(zc.type(), ntsa::ZeroCopyType::e_AVOIDED);
     }
     {
-        const bsl::uint32_t from = 5;
-        const bsl::uint32_t to   = 15;
-        const bsl::uint8_t  code = 1;
+        const bsl::uint32_t             from = 5;
+        const bsl::uint32_t             thru = 15;
+        const ntsa::ZeroCopyType::Value type = ntsa::ZeroCopyType::e_DEFERRED;
 
-        ZeroCopy zc(from, to, code);
+        ZeroCopy zc(from, thru, type);
         NTSCFG_TEST_EQ(zc.from(), from);
-        NTSCFG_TEST_EQ(zc.to(), to);
-        NTSCFG_TEST_EQ(zc.code(), code);
+        NTSCFG_TEST_EQ(zc.thru(), thru);
+        NTSCFG_TEST_EQ(zc.type(), type);
     }
     {
-        const bsl::uint32_t from = 10;
-        const bsl::uint32_t to   = 22;
-        const bsl::uint8_t  code = 1;
+        const bsl::uint32_t             from = 10;
+        const bsl::uint32_t             thru = 22;
+        const ntsa::ZeroCopyType::Value type = ntsa::ZeroCopyType::e_DEFERRED;
         
         ZeroCopy zc;
         zc.setFrom(from);
-        zc.setTo(to);
-        zc.setCode(code);
+        zc.setThru(thru);
+        zc.setType(type);
         NTSCFG_TEST_EQ(zc.from(), from);
-        NTSCFG_TEST_EQ(zc.to(), to);
-        NTSCFG_TEST_EQ(zc.code(), code);
+        NTSCFG_TEST_EQ(zc.thru(), thru);
+        NTSCFG_TEST_EQ(zc.type(), type);
 
         ZeroCopy copy(zc);
         NTSCFG_TEST_EQ(copy, zc);

--- a/groups/nts/ntsu/ntsu_socketoptionutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.cpp
@@ -705,7 +705,7 @@ ntsa::Error SocketOptionUtil::setZeroCopy(ntsa::Handle socket, bool zeroCopy)
 {
 #if defined(BSLS_PLATFORM_OS_LINUX)
 
-    int optionValue = static_cast<bool>(zeroCopy);
+    int optionValue = static_cast<int>(zeroCopy);
 
     int rc = setsockopt(socket,
                         SOL_SOCKET,

--- a/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
@@ -1792,8 +1792,6 @@ NTSCFG_TEST_CASE(9)
             if (!ntsu::AdapterUtil::supportsIpv4()) {
                 continue;
             }
-
-            zeroCopyEnabledByDefault = true;
         }
 
         if (transport == ntsa::Transport::e_TCP_IPV6_STREAM ||
@@ -1802,8 +1800,6 @@ NTSCFG_TEST_CASE(9)
             if (!ntsu::AdapterUtil::supportsIpv6()) {
                 continue;
             }
-
-            zeroCopyEnabledByDefault = true;
         }
 
 #if defined(BSLS_PLATFORM_OS_LINUX)

--- a/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketoptionutil.t.cpp
@@ -1778,6 +1778,8 @@ NTSCFG_TEST_CASE(9)
 #endif
     };
 
+    bool zeroCopyEnabledByDefault = false;
+
     for (bsl::size_t socketTypeIndex = 0;
          socketTypeIndex < sizeof(SOCKET_TYPES) / sizeof(SOCKET_TYPES[0]);
          ++socketTypeIndex)
@@ -1790,6 +1792,8 @@ NTSCFG_TEST_CASE(9)
             if (!ntsu::AdapterUtil::supportsIpv4()) {
                 continue;
             }
+
+            zeroCopyEnabledByDefault = true;
         }
 
         if (transport == ntsa::Transport::e_TCP_IPV6_STREAM ||
@@ -1798,6 +1802,8 @@ NTSCFG_TEST_CASE(9)
             if (!ntsu::AdapterUtil::supportsIpv6()) {
                 continue;
             }
+
+            zeroCopyEnabledByDefault = true;
         }
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
@@ -1855,11 +1861,11 @@ NTSCFG_TEST_CASE(9)
         NTSCFG_TEST_OK(error);
 
         if (setSupported && getSupported) {
-            bool zeroCopy = true;
+            bool zeroCopy = !zeroCopyEnabledByDefault;
             error =
                 ntsu::SocketOptionUtil::getZeroCopy(&zeroCopy, socket);
             NTSCFG_TEST_OK(error);
-            NTSCFG_TEST_FALSE(zeroCopy);
+            NTSCFG_TEST_EQ(zeroCopy, zeroCopyEnabledByDefault);
 
             error = ntsu::SocketOptionUtil::setZeroCopy(socket, true);
             NTSCFG_TEST_OK(error);

--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -1399,6 +1399,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1407,6 +1414,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -1473,6 +1486,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1481,6 +1501,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -1544,6 +1570,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1552,6 +1585,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -1614,6 +1653,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*            context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1622,6 +1668,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*            context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -1684,6 +1736,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*               context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1692,6 +1751,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*               context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -1758,6 +1823,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*         context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1766,6 +1838,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*         context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -1829,6 +1907,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*         context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1837,6 +1922,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*         context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -1899,6 +1990,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*              context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1907,6 +2005,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*              context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -1968,6 +2072,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*                 context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -1976,6 +2087,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*                 context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -2041,6 +2158,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -2049,6 +2173,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -2148,6 +2278,13 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
 
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
+
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
                                          sendmsgResult,
@@ -2156,6 +2293,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 
@@ -2220,8 +2363,14 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     }
 #endif
 
-    ssize_t sendmsgResult =
-        ::sendmsg(socket, &msg, sendFlags);
+    ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+        sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
+        sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
+    }
+#endif
 
     NTSU_SOCKETUTIL_DEBUG_SENDMSG_UPDATE(msg.msg_iov,
                                          msg.msg_iovlen,
@@ -2231,6 +2380,12 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     if (sendmsgResult < 0) {
         return ntsa::Error(errno);
     }
+
+#if defined(BSLS_PLATFORM_OS_LINUX)
+    if ((sendFlags & ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY) != 0) {
+        context->setZeroCopy(true);
+    }
+#endif
 
     context->setBytesSent(sendmsgResult);
 

--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -1109,28 +1109,6 @@ ntsa::Error SocketUtil::create(ntsa::Handle*          result,
         }
     }
 
-#if defined(BSLS_PLATFORM_OS_LINUX)
-    // To cause 'sendmsg' to honor the MSG_ZEROCOPY flag we must set a 
-    // socket option when the socket is in its initial state.
-
-    if (domain == AF_INET || domain == AF_INET6) {
-        int optionValue = 1;
-        rc = ::setsockopt(*result,
-                          SOL_SOCKET,
-                          ntsu::ZeroCopyUtil::e_SO_ZEROCOPY,
-                          &optionValue,
-                          sizeof optionValue);
-
-        if (rc != 0) {
-            int lastError = errno;
-            if (lastError != ENOTSUP) {
-                BSLS_LOG_WARN("Failed to set socket option: zero-copy: %s", 
-                              ntsa::Error(lastError).text().c_str());
-            }
-        }
-    }
-#endif
-
 #if NTSU_SOCKETUTIL_DEBUG_LIFETIME
     NTSU_SOCKETUTIL_DEBUG_LIFETIME_LOG("Socket handle %d created", *result);
 #endif

--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -3545,8 +3545,21 @@ ntsa::Error SocketUtil::receiveNotifications(
                 else if (ser.ee_origin ==
                          ntsu::ZeroCopyUtil::e_SO_EE_ORIGIN_ZEROCOPY)
                 {
-                    ntsa::ZeroCopy zc(ser.ee_info, ser.ee_data, ser.ee_code);
-                    notification.makeZeroCopy(zc);
+                    ntsa::ZeroCopy zeroCopy;
+
+                    zeroCopy.setFrom(ser.ee_info);
+                    zeroCopy.setThru(ser.ee_data);
+                    
+                    if (ser.ee_code == 
+                        ntsu::ZeroCopyUtil::e_SO_EE_CODE_ZEROCOPY_COPIED) 
+                    {
+                        zeroCopy.setType(ntsa::ZeroCopyType::e_DEFERRED);
+                    }
+                    else {
+                        zeroCopy.setType(ntsa::ZeroCopyType::e_AVOIDED);
+                    }
+
+                    notification.makeZeroCopy(zeroCopy);
                     notifications->addNotification(notification);
                 }
             }

--- a/groups/nts/ntsu/ntsu_socketutil.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.cpp
@@ -1400,7 +1400,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -1487,7 +1490,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -1571,7 +1577,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -1654,7 +1663,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*            context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -1737,7 +1749,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*               context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -1824,7 +1839,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*         context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -1908,7 +1926,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*         context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -1991,7 +2012,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*              context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -2073,7 +2097,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*                 context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -2159,7 +2186,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -2279,7 +2309,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -2366,7 +2399,10 @@ ntsa::Error SocketUtil::send(ntsa::SendContext*       context,
     ssize_t sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
 
 #if defined(BSLS_PLATFORM_OS_LINUX)
-    if (NTSCFG_UNLIKELY(sendmsgResult < 0 && errno == ENOBUFS)) {
+    if (NTSCFG_UNLIKELY(sendmsgResult < 0 &&
+                        errno == ENOBUFS &&
+                        options.zeroCopy()))
+    {
         sendFlags &= ~ntsu::ZeroCopyUtil::e_MSG_ZEROCOPY;
         sendmsgResult = ::sendmsg(socket, &msg, sendFlags);
     }
@@ -3532,8 +3568,8 @@ ntsa::Error SocketUtil::receiveNotifications(
                     zeroCopy.setFrom(ser.ee_info);
                     zeroCopy.setThru(ser.ee_data);
 
-                    if (ser.ee_code == 
-                        ntsu::ZeroCopyUtil::e_SO_EE_CODE_ZEROCOPY_COPIED) 
+                    if (ser.ee_code ==
+                        ntsu::ZeroCopyUtil::e_SO_EE_CODE_ZEROCOPY_COPIED)
                     {
                         zeroCopy.setType(ntsa::ZeroCopyType::e_DEFERRED);
                     }

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -158,8 +158,9 @@ void extractZeroCopyNotifications(bsl::list<ntsa::ZeroCopy>* zerocopy,
          it != notifications.notifications().cend();
          ++it)
     {
-        NTSCFG_TEST_TRUE(it->isZeroCopy());
-        zerocopy->push_back(it->zeroCopy());
+        if (it->isZeroCopy()) {
+            zerocopy->push_back(it->zeroCopy());
+        }
     }
 }
 
@@ -182,8 +183,9 @@ void extractTimestampNotifications(bsl::list<ntsa::Timestamp>* ts,
          it != notifications.notifications().cend();
          ++it)
     {
-        NTSCFG_TEST_TRUE(it->isTimestamp());
-        ts->push_back(it->timestamp());
+        if (it->isTimestamp()) {
+            ts->push_back(it->timestamp());
+        }
     }
 }
 
@@ -2149,7 +2151,7 @@ void testStreamSocketTxTimestamps(ntsa::Transport::Value transport,
     for (int i = 0; i < numMessagesToSend; ++i) {
         ntsa::SendContext context;
         ntsa::SendOptions options;
-        options.setZeroCopy(true);
+        options.setZeroCopy(false);
 
         const bsls::TimeInterval sysTimeBeforeSending =
             bdlt::CurrentTime::now();

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -152,15 +152,13 @@ void extractZeroCopyNotifications(bsl::list<ntsa::ZeroCopy>* zerocopy,
 
     NTSCFG_TEST_LOG_DEBUG << notifications << NTSCFG_TEST_LOG_END;
 
-    // save zerocopy notifications for later validation
     for (bsl::vector<ntsa::Notification>::const_iterator it =
              notifications.notifications().cbegin();
          it != notifications.notifications().cend();
          ++it)
     {
-        if (it->isZeroCopy()) {
-            zerocopy->push_back(it->zeroCopy());
-        }
+        NTSCFG_TEST_TRUE(it->isZeroCopy());
+        zerocopy->push_back(it->zeroCopy());
     }
 }
 
@@ -177,15 +175,13 @@ void extractTimestampNotifications(bsl::list<ntsa::Timestamp>* ts,
 
     NTSCFG_TEST_LOG_DEBUG << notifications << NTSCFG_TEST_LOG_END;
 
-    // save zerocopy notifications for later validation
     for (bsl::vector<ntsa::Notification>::const_iterator it =
              notifications.notifications().cbegin();
          it != notifications.notifications().cend();
          ++it)
     {
-        if (it->isTimestamp()) {
-            ts->push_back(it->timestamp());
-        }
+        NTSCFG_TEST_TRUE(it->isTimestamp());
+        ts->push_back(it->timestamp());
     }
 }
 
@@ -202,7 +198,6 @@ void extractNotifications(bsl::list<ntsa::Notification>* nt,
 
     NTSCFG_TEST_LOG_DEBUG << notifications << NTSCFG_TEST_LOG_END;
 
-    // save zerocopy notifications for later validation
     for (bsl::vector<ntsa::Notification>::const_iterator it =
              notifications.notifications().cbegin();
          it != notifications.notifications().cend();

--- a/groups/nts/ntsu/ntsu_socketutil.t.cpp
+++ b/groups/nts/ntsu/ntsu_socketutil.t.cpp
@@ -1984,12 +1984,12 @@ void testStreamSocketMsgZeroCopy(ntsa::Transport::Value transport,
 
         while (!feedback.empty()) {
             const ntsa::ZeroCopy& zc = feedback.front();
-            NTSCFG_TEST_EQ(zc.code(), 1);  // we know that OS copied data
-            if (zc.from() == zc.to()) {
+            NTSCFG_TEST_EQ(zc.type(), ntsa::ZeroCopyType::e_DEFERRED);  // we know that OS copied data
+            if (zc.from() == zc.thru()) {
                 NTSCFG_TEST_EQ(sendIDs.erase(zc.from()), 1);
             }
             else {
-                for (bsl::uint32_t i = zc.from(); i != (zc.to() + 1); ++i) {
+                for (bsl::uint32_t i = zc.from(); i != (zc.thru() + 1); ++i) {
                     NTSCFG_TEST_EQ(sendIDs.erase(i), 1);
                 }
             }
@@ -2338,12 +2338,12 @@ void testDatagramSocketTxTimestampsAndZeroCopy(
             }
             else if (nt.isZeroCopy()) {
                 const ntsa::ZeroCopy& zc = nt.zeroCopy();
-                NTSCFG_TEST_EQ(zc.code(), 1);
-                if (zc.from() == zc.to()) {
+                NTSCFG_TEST_EQ(zc.type(), ntsa::ZeroCopyType::e_DEFERRED);
+                if (zc.from() == zc.thru()) {
                     NTSCFG_TEST_EQ(zeroCopyToValidate.erase(zc.from()), 1);
                 }
                 else {
-                    for (bsl::uint32_t i = zc.from(); i != (zc.to() + 1); ++i)
+                    for (bsl::uint32_t i = zc.from(); i != (zc.thru() + 1); ++i)
                     {
                         NTSCFG_TEST_EQ(zeroCopyToValidate.erase(i), 1);
                     }
@@ -2477,12 +2477,12 @@ void testStreamSocketTxTimestampsAndZeroCopy(ntsa::Transport::Value transport,
             }
             else if (nt.isZeroCopy()) {
                 const ntsa::ZeroCopy& zc = nt.zeroCopy();
-                NTSCFG_TEST_EQ(zc.code(), 1);
-                if (zc.from() == zc.to()) {
+                NTSCFG_TEST_EQ(zc.type(), ntsa::ZeroCopyType::e_DEFERRED);
+                if (zc.from() == zc.thru()) {
                     NTSCFG_TEST_EQ(zeroCopyToValidate.erase(zc.from()), 1);
                 }
                 else {
-                    for (bsl::uint32_t i = zc.from(); i != (zc.to() + 1); ++i)
+                    for (bsl::uint32_t i = zc.from(); i != (zc.thru() + 1); ++i)
                     {
                         NTSCFG_TEST_EQ(zeroCopyToValidate.erase(i), 1);
                     }
@@ -7834,11 +7834,11 @@ NTSCFG_TEST_CASE(27)
 
                 while (!feedback.empty()) {
                     const ntsa::ZeroCopy& zc = feedback.front();
-                    if (zc.from() == zc.to()) {
+                    if (zc.from() == zc.thru()) {
                         NTSCFG_TEST_EQ(sendIDs.erase(zc.from()), 1);
                     }
                     else {
-                        for (bsl::uint32_t i = zc.from(); i != (zc.to() + 1);
+                        for (bsl::uint32_t i = zc.from(); i != (zc.thru() + 1);
                              ++i)
                         {
                             NTSCFG_TEST_EQ(sendIDs.erase(i), 1);


### PR DESCRIPTION
This PR significantly revises the implementation to support zero-copy on Linux, but retains the general structure of the original proposal.

- `ntsa::ZeroCopy::to()` is renamed to `ntsa::ZeroCopy::thru()` to hopefully emphasize that it is inclusive (i.e. `ntsa::ZeroCopy` represents a closed range)
- `ntsa::ZeroCopy::code()` has been changed to `ntsa::ZeroCopy::type()` that returns a new enumeration, `ntsa::ZeroCopyType::Value`, for readability and consistency with the rest of the library
- The zero copy threshold is now configurable in per-socket options, as well as a default option in `ntca::InterfaceConfig`
- `ntsa::SendOptions` already contains a new flag indicating that a zero-copy `sendmsg` should be tried, now `ntsa::SendContext` contains a flag that indicates whether it was actually performed
- Handling `ENOBUFS` is pushed down into `ntsu::SocketUtil::send`. When a zero-copy `sendmsg` fails with `ENOBUFS` it is automatically retried as a traditional `sendmsg`. Whether or not a zero-copy was actually initiated is now indicated in the `ntsa::SendContext` output parameter.
- Separate code paths for `ntci::Sender::send` with and without a callback have been merged into one code path
- The send path of `ntcr::DatagramSocket` and `ntcr::StreamSocket` has been greatly simplified leveraging the previous changes
- Timestamping and zero-copying can now all be changed during the operation of an `ntci::DatagramSocket` and `ntci::StreamSocket`, not just at the time of their construction
- `ntcq::SendCallbackQueueEntry` has been removed and we now simply store `ntci::SendCallback` in a `ntcq::SendQueueEntry`.
- The zero-copy data structure has been renamed from `ntcq::ZeroCopyWaitList` to `ntcq::ZeroCopyQueue` and had its interface modified to support the following necessary cases/requirements: a) Sending a `bldbb::Blob` may require multiple `sendmsg` calls (and often does), b) Some `sendmsg` calls for the same `bdlbb::Blob` may zero-copy and others may not, c) We need to know when no more zero copy counters for a send operation are expected to be forthcoming (see `ntcq::ZeroCopyQueue::frame()`), d) the send callback (if any) must be invoked exactly once, e) the `ntsa::Data` must be stored while all zero-copy operations that source it are pending in the Linux kernel.
- Zero-copy counters may complete out-of-order so we need to handle complex splits of the expected zero-copy intervals  that reference an `ntsa::Data` (see ntcq_zerocopy.t.cpp test case 13)
- To simplify the math computing zero-copy interval set intersection and difference, `ntcq_zerocopy` transforms the 32-bit zero copy counters in `ntsa::ZeroCopy` into a 64-bit range, detecting 32-bit wraparound as necessary
- To cause the kernel to respect MSG_ZEROCOPY as a flag to `sendmsg`, we must first set a `SO_ZEROCOPY` socket option. But that option may only be set for TCP sockets that are in the default state (i.e., not after the socket is connected). To respect this `ntsu::SocketUtil::create` now sets the option automatically for IPv4 and IPv6 sockets.
